### PR TITLE
Don't call init_model() twice.

### DIFF
--- a/chacra/commands/populate.py
+++ b/chacra/commands/populate.py
@@ -17,7 +17,6 @@ class PopulateCommand(BaseCommand):
         super(PopulateCommand, self).run(args)
         out("LOADING ENVIRONMENT")
         self.load_app()
-        models.init_model()
         out("BUILDING SCHEMA")
         try:
             out("STARTING A TRANSACTION...")


### PR DESCRIPTION
This is in relation to the issue @alfredodeza shared with me: http://fpaste.org/256509/39421143/

For the populate command, you're inadvertently calling `model.init_model` twice (which you don't need to do):

https://github.com/ceph/chacra/blob/master/chacra/commands/populate.py#L19
https://github.com/pecan/pecan/blob/master/pecan/core.py#L221
https://github.com/ceph/chacra/blob/master/chacra/app.py#L7

In versions of pecan (prior to 1.0.1) the ``setattr`` portion of this line was not actually having the desired effect:

https://github.com/ceph/chacra/blob/master/chacra/models/__init__.py#L72

...because of this bug, which was fixed in 1.0.1:

https://github.com/pecan/pecan/pull/4

So in pecan 1.0.1, where the bug is fixed, you're modifying ``conf.sqlalchemy`` to have an `engine` property, and when `model.init_model` is called the *second* time...

https://github.com/ceph/chacra/blob/master/chacra/models/__init__.py#L72

...it complains (because `engine` is not a valid argument to ``sqlalchemy.create_engine``)
