### PR TITLE
Implement Authentication for binaries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,28 @@ So for a CentOS 7 x86_64 package for Ceph the url could look like::
     /projects/ceph/firefly/centos/7/x86_64/ceph-0.87.2-0.el7.centos.x86_64.rpm
 
 
+Configuration
+-------------
+The service needs to be configured with a few items to correctly work with
+binaries.
+
+binary_root
+^^^^^^^^^^^
+The ``binary_root`` is a required configuration item, it defines where binaries
+live so that when a new binary is POSTed the service will use this path to save
+the binary to.
+
+credentials
+^^^^^^^^^^^
+The POST and DELETE HTTP methods are protected by default using basic HTTP
+authentication. The credentials must be defined in the configuration file for
+the service as follows::
+
+    api_user = 'username'
+    api_key = 'secret'
+
+
+
 Self-discovery
 --------------
 The API provides informational JSON at every step of the URL about what is

--- a/chacra/auth.py
+++ b/chacra/auth.py
@@ -2,7 +2,7 @@ import base64
 from pecan import request, abort, response, conf
 
 
-def simple_auth():
+def basic_auth():
     try:
         auth = request.headers.get('Authorization')
         assert auth

--- a/chacra/auth.py
+++ b/chacra/auth.py
@@ -1,0 +1,18 @@
+import base64
+from pecan import request, abort, response, conf
+
+
+def simple_auth():
+    try:
+        auth = request.headers.get('Authorization')
+        assert auth
+        decoded = base64.b64decode(auth.split(' ')[1])
+        username, password = decoded.split(':')
+
+        assert username == conf.api_user
+        assert password == conf.api_key
+    except:
+        response.headers['WWW-Authenticate'] = 'Basic realm="Chacra :: Binary API"'
+        abort(401)
+
+    return True

--- a/chacra/controllers/binaries.py
+++ b/chacra/controllers/binaries.py
@@ -1,9 +1,11 @@
 import os
 import pecan
 from pecan import expose, abort, request, response, conf
+from pecan.secure import secure
 from webob.static import FileIter
 from chacra.models import Binary, Project
 from chacra.controllers import error
+from chacra.auth import basic_auth
 
 
 class BinaryController(object):
@@ -52,6 +54,7 @@ class BinaryController(object):
         else:
             response.headers['X-Accel-Redirect'] = str(self.binary.path)
 
+    @secure(basic_auth)
     @index.when(method='POST', template='json')
     def index_post(self):
         contents = request.POST.get('file', False)

--- a/chacra/tests/config.py
+++ b/chacra/tests/config.py
@@ -76,3 +76,5 @@ binary_root = '/tmp/'
 # instead of Pecan.
 delegate_downloads = False
 
+api_user = 'admin'
+api_key = 'secret'

--- a/chacra/tests/conftest.py
+++ b/chacra/tests/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
 from chacra import models as _db
+from chacra.tests import util
 import pytest
 
 
@@ -146,6 +147,9 @@ class TestApp(object):
         @param (string) url - The URL to emulate a POST request to
         @returns (paste.fixture.TestResponse)
         """
+        # support automatic, correct authentication if not specified otherwise
+        if not kwargs.get('headers'):
+            kwargs['headers'] = {'Authorization': util.make_credentials()}
         return self._do_request(url, 'POSTJ', **kwargs)
 
     def post(self, url, **kwargs):
@@ -153,6 +157,9 @@ class TestApp(object):
         @param (string) url - The URL to emulate a POST request to
         @returns (paste.fixture.TestResponse)
         """
+        # support automatic, correct authentication if not specified otherwise
+        if not kwargs.get('headers'):
+            kwargs['headers'] = {'Authorization': util.make_credentials()}
         return self._do_request(url, 'POST', **kwargs)
 
     def get(self, url, **kwargs):

--- a/chacra/tests/controllers/test_binaries.py
+++ b/chacra/tests/controllers/test_binaries.py
@@ -1,6 +1,7 @@
 import os
 import pecan
 from chacra.models import Binary
+from chacra.tests import util
 
 
 class TestBinaryUniqueness(object):
@@ -36,6 +37,15 @@ class TestBinaryController(object):
             upload_files=[('file', 'ceph-9.0.0-0.el6.x86_64.rpm', 'hello tharrrr')]
         )
         assert result.status_int == 201
+
+    def test_auth_fails(self, session):
+        result = session.app.post(
+            '/projects/ceph/giant/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/',
+            upload_files=[('file', 'ceph-9.0.0-0.el6.x86_64.rpm', 'hello tharrrr')],
+            headers={'Authorization': util.make_credentials(correct=False)},
+            expect_errors=True
+        )
+        assert result.status_int == 401
 
     def test_new_binary_upload_creates_model_with_path_forced(self, session, tmpdir):
         pecan.conf.binary_root = str(tmpdir)

--- a/chacra/tests/util.py
+++ b/chacra/tests/util.py
@@ -1,0 +1,13 @@
+from pecan import conf
+import base64
+
+
+def make_credentials(correct=True, username=None, secret=None):
+    if correct and not username and not secret:
+        creds = "%s:%s" % (conf.api_user, conf.api_key)
+    elif username and secret:
+        creds = "%s:%s" % (username, secret)
+    else:
+        creds = 'you:wrong'
+    return 'Basic %s' % base64.b64encode(creds)
+


### PR DESCRIPTION
Uses Basic HTTP Auth. Adds tests for it  (and fixes broken ones), and it updates the documentation so that it correctly explains what we expect.