### PR TITLE
Adds a new repos role that configures the node to build repos

### DIFF
--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -4,6 +4,7 @@
   user: centos
   roles:
     - common
+    - repos
   vars:
      app_name: "chacra"
      use_ssl: true

--- a/deploy/playbooks/deploy_vagrant.yml
+++ b/deploy/playbooks/deploy_vagrant.yml
@@ -4,6 +4,7 @@
   user: vagrant
   roles:
     - common
+    - repos
   vars:
      app_name: "chacra"
      use_ssl: true

--- a/deploy/playbooks/roles/repos/defaults/main.yml
+++ b/deploy/playbooks/roles/repos/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+reprepro_distros:
+  - sid
+  - wheezy
+  - squeeze
+  - raring
+  - quantal
+  - precise
+  - saucy
+  - trusty

--- a/deploy/playbooks/roles/repos/tasks/main.yml
+++ b/deploy/playbooks/roles/repos/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Update apt
+  sudo: yes
+  apt:
+    update_cache: yes
+
+- name: Install needed packages
+  sudo: yes 
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - reprepro
+    - createrepo
+
+- name: Upload debian distributions file for use with reprepro
+  sudo: yes
+  template:
+    src: distributions
+    dest: /etc/distributions

--- a/deploy/playbooks/roles/repos/templates/distributions
+++ b/deploy/playbooks/roles/repos/templates/distributions
@@ -1,0 +1,12 @@
+{% for distro in reprepro_distros %}
+Codename: {{ distro }}
+Suite: stable
+Components: main
+Architectures: amd64 armhf i386 source
+Origin: RedHat
+Description: Ceph distributed file system
+DebIndices: Packages Release . .gz .bz2
+DscIndices: Sources Release .gz .bz2
+Contents: .gz .bz2
+
+{% endfor %}


### PR DESCRIPTION
This role does not yet quite work with the common role as we have to target Ubuntu for repo creation because we want to build both rpm and deb repos on the same node.

A port of the common role to Ubuntu will be necessary.