### PR TITLE
Remove raring from reprepro_distros list in the repos role

### DIFF
--- a/deploy/playbooks/roles/repos/defaults/main.yml
+++ b/deploy/playbooks/roles/repos/defaults/main.yml
@@ -3,7 +3,6 @@ reprepro_distros:
   - sid
   - wheezy
   - squeeze
-  - raring
   - quantal
   - precise
   - saucy


### PR DESCRIPTION
raring is EOLd

Signed-off-by: Andrew Schoen <aschoen@redhat.com>