### PR TITLE
Port the common role from centos 7 to ubuntu trusty

### DIFF
--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: all
-  user: centos
+  user: ubuntu
   roles:
     - common
     - repos

--- a/deploy/playbooks/deploy_vagrant.yml
+++ b/deploy/playbooks/deploy_vagrant.yml
@@ -12,3 +12,4 @@
      wsgi_callable: application
      ansible_ssh_port: 22
      restart_app: true
+     binary_root: "/opt/binaries"

--- a/deploy/playbooks/roles/common/handlers/main.yml
+++ b/deploy/playbooks/roles/common/handlers/main.yml
@@ -21,7 +21,3 @@
 - name: restart circus
   sudo: yes
   action: service name=circus state=restarted
-
-- name: reload systemctl
-  command: systemctl daemon-reload
-  sudo: yes

--- a/deploy/playbooks/roles/common/tasks/circus.yml
+++ b/deploy/playbooks/roles/common/tasks/circus.yml
@@ -18,19 +18,18 @@
 - name: ensure {{ app_home }}/log exists
   file: path="{{ app_home }}/log" state=directory
 
-- name: install circus systemd service file
-  template: src=circus.service.j2 dest=/etc/systemd/system/circus.service
+- name: install circus.conf init file
+  template:
+    src: circus.conf
+    dest: /etc/init/circus.conf
   sudo: true
   register: circus_service
 
-- name: reload the systemctl daemon
-  when: circus_service.changed
-  sudo: true
-  command: systemctl --system daemon-reload
-
 - name: enable circus
   sudo: true
-  action: service name=circus enabled=yes
+  service:
+    name: circus
+    enabled: yes
 
 - name: install circus conf for {{ app_name }}
   template: src=circus.ini.j2 dest=/etc/circus/circus.ini
@@ -39,4 +38,6 @@
 
 - name: ensure circus is running
   sudo: true
-  action: service name=circus state=started
+  service:
+    name: circus
+    state: started

--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -1,29 +1,34 @@
 ---
 
-- name: ensure a home for {{ app_name }}
+- name: "ensure a home for {{ app_name }}"
   sudo: yes
   file: path={{ app_home }} owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} state=directory recurse=yes
 
+- name: Update apt cache
+  apt:
+    update_cache: yes
+  sudo: yes
+
 - name: install ssl system requirements
   sudo: yes
-  yum: name={{ item }} state=present
+  apt: name={{ item }} state=present
   with_items: ssl_requirements
   when: app_use_ssl
-
-- name: enable EPEL
-  sudo: yes
-  yum: name=epel-release state=present
+  tags:
+    - packages
 
 - name: install system packages
   sudo: yes
-  yum: name={{ item }} state=present
+  apt: name={{ item }} state=present
   with_items: system_packages
+  tags:
+    - packages
 
 - name: Create a virtualenv with latest pip.
   pip: name=pip virtualenv={{ app_home }} extra_args='--upgrade'
 
-- name: pip+git install {{ app_name }} into virtualenv.
-  pip: name='git+https://github.com/alfredodeza/chacra#egg=chacra' virtualenv={{ app_home }}
+- name: "pip+git install {{ app_name }} into virtualenv."
+  pip: name='git+https://github.com/ceph/chacra#egg=chacra' virtualenv={{ app_home }}
   changed_when: False
 
 - name: create the prod config file
@@ -37,7 +42,13 @@
   notify: restart app
 
 - include: postgresql.yml
+  tags:
+    - postgres
 
 - include: circus.yml
+  tags:
+    - circus
 
 - include: nginx.yml
+  tags:
+    - nginx

--- a/deploy/playbooks/roles/common/tasks/nginx.yml
+++ b/deploy/playbooks/roles/common/tasks/nginx.yml
@@ -1,41 +1,34 @@
 ---
-  - name: Set SELinux to allow Nginx to proxy
-    sudo: true
-    seboolean:
-      name: httpd_can_network_connect
-      state: yes
-      persistent: yes
+- name: ensure sites-available for nginx
+  file: path=/etc/nginx/sites-available state=directory
+  sudo: true
 
-  - name: ensure sites-available for nginx
-    file: path=/etc/nginx/sites-available state=directory
-    sudo: true
+- name: ensure sites-enable for nginx
+  file: path=/etc/nginx/sites-enabled state=directory
+  sudo: true
 
-  - name: ensure sites-enable for nginx
-    file: path=/etc/nginx/sites-enabled state=directory
-    sudo: true
+- name: remove default nginx site
+  action: file path=/etc/nginx/sites-enabled/default state=absent
+  sudo: true
 
-  - name: remove default nginx site
-    action: file path=/etc/nginx/sites-enabled/default state=absent
-    sudo: true
+- name: write nginx.conf
+  action: template src=../templates/nginx.conf dest=/etc/nginx/nginx.conf
+  sudo: true
 
-  - name: write nginx.conf
-    action: template src=../templates/nginx.conf dest=/etc/nginx/nginx.conf
-    sudo: true
+- name: enable nginx
+  sudo: true
+  action: service name=nginx enabled=true
 
-  - name: enable nginx
-    sudo: true
-    action: service name=nginx enabled=true
+- name: create nginx site config
+  action: template src=../templates/nginx_site.conf dest=/etc/nginx/sites-available/{{ app_name }}.conf
+  sudo: true
+  notify:
+    - restart nginx
 
-  - name: create nginx site config
-    action: template src=../templates/nginx_site.conf dest=/etc/nginx/sites-available/{{ app_name }}.conf
-    sudo: true
-    notify:
-      - restart nginx
+- name: link nginx config
+  action: file src=/etc/nginx/sites-available/{{ app_name }}.conf dest=/etc/nginx/sites-enabled/{{ app_name }}.conf state=link
+  sudo: true
 
-  - name: link nginx config
-    action: file src=/etc/nginx/sites-available/{{ app_name }}.conf dest=/etc/nginx/sites-enabled/{{ app_name }}.conf state=link
-    sudo: true
-
-  - name: ensure nginx is started
-    sudo: true
-    action: service name=nginx state=started
+- name: ensure nginx is started
+  sudo: true
+  action: service name=nginx state=started

--- a/deploy/playbooks/roles/common/tasks/postgresql.yml
+++ b/deploy/playbooks/roles/common/tasks/postgresql.yml
@@ -1,79 +1,76 @@
 ---
-   - name: initialize postgresql
-     command: postgresql-setup initdb
-             creates=/var/lib/pgsql/data/postgresql.conf
-     sudo: yes
+- name: ensure database service is up
+  service:
+    name: postgresql
+    state: started
+  sudo: yes
 
-   - name: ensure database service is up
-     service:
-       name: postgresql
-       state: started
-     sudo: yes
+- name: allow users to connect locally
+  sudo: yes
+  lineinfile:
+     # TODO: should not hardcode that version
+     dest: /etc/postgresql/9.3/main/pg_hba.conf
+     regexp: '^host\s+all\s+all\s+127.0.0.1/32'
+     line: 'host    all             all             127.0.0.1/32            md5'
+     backrefs: yes
+  register: pg_hba_conf
 
-   - name: check if app user exists
-     command: psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='{{ app_name }}'"
-     sudo_user: postgres
-     sudo: yes
-     register: db_user_exists
-     changed_when: False
+- service:
+    name: postgresql
+    state: restarted
+  sudo: true
+  when: pg_hba_conf.changed
 
-   # FIXME: flag/option needed
-   # this is a bit of chicken-or-egg problem. If the user for the app does
-   # exist but we failed to set the password in both postgresql and the python
-   # config file then we will fail to reset it next time around. This would
-   # leave the app without the access to the database.
-   - name: generate pseudo-random password for the database connection
-     shell: python -c "exec 'import os; print os.urandom(30).encode(\'base64\')[:${length}]'"
-     register: db_password
-     #when: db_user_exists.stdout == '0' or db_user_exists.stdout == ''
+# FIXME: flag/option needed
+# this is a bit of chicken-or-egg problem. If the user for the app does
+# exist but we failed to set the password in both postgresql and the python
+# config file then we will fail to reset it next time around. This would
+# leave the app without the access to the database.
+- name: generate pseudo-random password for the database connection
+  shell: python -c "exec 'import os; print os.urandom(30).encode(\'base64\')[:${length}]'"
+  register: db_password
+  changed_when: false
 
-   - name: allow users to connect locally
-     sudo: yes
-     lineinfile:
-        dest: /var/lib/pgsql/data/pg_hba.conf
-        regexp: '^host\s+all\s+all\s+127.0.0.1/32'
-        line: 'host    all             all             127.0.0.1/32            md5'
-        backrefs: yes
-     register: pg_hba_conf
+- name: Make {{ app_name }} user
+  postgresql_user:
+    name: "{{ app_name }}" 
+    password: "{{ db_password.stdout }}"
+    role_attr_flags: SUPERUSER
+    login_user: postgres
+  sudo_user: postgres
+  sudo: yes
 
-   - service:
-       name: postgresql
-       state: restarted
-     sudo: true
-     when: pg_hba_conf.changed
+- name: Make {{ app_name }} database
+  postgresql_db:
+    name: "{{ app_name }}"
+    owner: "{{ app_name }}"
+    state: present
+    login_user: postgres
+  sudo_user: postgres
+  sudo: yes
 
-   - name: ensure database service is up
-     service:
-       name: postgresql
-       state: started
-     sudo: yes
+- name: ensure database service is up
+  service:
+    name: postgresql
+    state: started
+  sudo: yes
 
-   - name: create app database
-     sudo_user: postgres
-     sudo: yes
-     action: postgresql_db db={{ app_name }}
+- name: create the prod_db config file with the db password
+  template:
+    src: ../templates/prod_db.py.j2
+    dest: "{{ app_home }}/src/{{ app_name }}/prod_db.py"
+  notify:
+    - restart app
 
-   - name: ensure user has access to databassss
-     sudo_user: postgres
-     sudo: yes
-     action: postgresql_user db="{{ app_name }}" user="{{ app_name }}" password="{{ db_password.stdout }}" role_attr_flags=NOSUPERUSER,CREATEDB
-     #when: db_user_exists.stdout == '0' or db_user_exists.stdout == ''
+- name: check if database for app needs populating
+  # this should be configurable/optional in the playbook
+  command: psql -t chacra -c "SELECT COUNT(*) FROM projects;"
+  sudo_user: postgres
+  sudo: yes
+  register: database_is_populated
+  ignore_errors: true
+  changed_when: "database_is_populated.rc != 0"
 
-   - name: create the prod_db config file with the db password
-     action: template src=../templates/prod_db.py.j2 dest={{ app_home }}/src/{{ app_name }}/prod_db.py
-     notify:
-       - restart app
-     #when: db_user_exists.stdout == '0' or db_user_exists.stdout == ''
-
-   - name: check if database for app needs populating
-     # this should be configurable/optional in the playbook
-     command: psql -t chacra -c "SELECT COUNT(*) FROM projects;"
-     sudo_user: postgres
-     sudo: yes
-     register: database_is_populated
-     ignore_errors: true
-     changed_when: "database_is_populated.rc != 0"
-
-   - name: populate the database for {{ app_name }}
-     when: "database_is_populated.rc == 1"
-     command: "{{ app_home }}/bin/pecan populate {{ app_home }}/src/{{ app_name }}/prod.py"
+- name: populate the database for {{ app_name }}
+  when: "database_is_populated.rc == 1"
+  command: "{{ app_home }}/bin/pecan populate {{ app_home }}/src/{{ app_name }}/prod.py"

--- a/deploy/playbooks/roles/common/templates/circus.conf
+++ b/deploy/playbooks/roles/common/templates/circus.conf
@@ -1,0 +1,2 @@
+start on filesystem and net-device-up IFACE=lo
+exec {{ app_home }}/bin/circusd /etc/circus/circus.ini

--- a/deploy/playbooks/roles/common/vars/main.yml
+++ b/deploy/playbooks/roles/common/vars/main.yml
@@ -1,23 +1,23 @@
 ---
 
 system_packages:
-  - python-devel
+  - python-dev
   - git
   - python-virtualenv
   - mongodb-server
-  - gcc-c++
+  - g++
   - gcc
-  - postgresql
-  - postgresql-libs
-  - postgresql-devel
-  - postgresql-server
+  - libpq-dev
+  - postgresql-9.3
+  - postgresql-common
+  - postgresql-contrib
   - python-psycopg2
   - nginx
-  - libsemanage-python
+#  - libsemanage-python
 
 ssl_requirements:
   - openssl
-  - openssl-devel
+  - libssl-dev
 
 circus_system_packages:
   - libzmq-dev


### PR DESCRIPTION
We needed to do this port because we want the cachra node to run
the api as well as do the repo creation work. Trusty is the only
distro, afaik, that supports the needed packages to do this.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>