### PR TITLE
automatic `modified` timestamps

### DIFF
--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -41,8 +41,9 @@ class Binary(Base):
     def __init__(self, name, project, **kw):
         self.name = name
         self.project = project
-        self.created = datetime.datetime.utcnow()
-        self.modified = datetime.datetime.utcnow()
+        now = datetime.datetime.utcnow()
+        self.created = now
+        self.modified = now
         for key in self.allowed_keys:
             if key in kw.keys():
                 setattr(self, key, kw[key])
@@ -110,5 +111,19 @@ def generate_checksum(mapper, connection, target):
             chsum.update(chunk)
         target.checksum = chsum.hexdigest()
 
+
+def update_timestamp(mapper, connection, target):
+    """
+    Automate the 'modified' attribute when a binary changes
+    """
+    target.modified = datetime.datetime.utcnow()
+
+
+# listen for checksum changes
 listen(Binary, 'before_insert', generate_checksum)
 listen(Binary, 'before_update', generate_checksum)
+
+
+# listen for timestamp modifications
+listen(Binary, 'before_insert', update_timestamp)
+listen(Binary, 'before_update', update_timestamp)

--- a/chacra/tests/models/test_binaries.py
+++ b/chacra/tests/models/test_binaries.py
@@ -1,0 +1,50 @@
+from chacra.models import Binary, Project
+
+
+class TestBinaryModification(object):
+
+    def setup(self):
+        self.p = Project('ceph')
+
+    def test_created_equals_modified_first_time_around(self, session):
+        binary = Binary(
+            'ceph-1.0.rpm',
+            self.p,
+            distro='centos',
+            distro_version='7',
+            arch='x86_64',
+            )
+        session.commit()
+        assert binary.created.timetuple() == binary.modified.timetuple()
+
+    def test_modified_gets_updated(self, session):
+        binary = Binary(
+            'ceph-1.0.rpm',
+            self.p,
+            distro='centos',
+            distro_version='7',
+            arch='x86_64',
+            )
+        session.commit()
+        initial_modified = binary.modified.time()
+        binary.ref = 'master'
+        session.commit()
+        binary = Binary.get(1)
+
+        assert initial_modified < binary.modified.time()
+
+    def test_modified_is_older_than_created(self, session):
+        binary = Binary(
+            'ceph-1.0.rpm',
+            self.p,
+            distro='centos',
+            distro_version='7',
+            arch='x86_64',
+            )
+        session.commit()
+        initial_created = binary.created.time()
+        binary.ref = 'master'
+        session.commit()
+        binary = Binary.get(1)
+
+        assert initial_created < binary.modified.time()


### PR DESCRIPTION
With SqlAlchemy listeners.

Adds tests for binary model.