### PR TITLE
More granular POST checks

### DIFF
--- a/chacra/controllers/binaries.py
+++ b/chacra/controllers/binaries.py
@@ -13,7 +13,15 @@ class BinaryController(object):
     def __init__(self, binary_name):
         self.binary_name = binary_name
         self.project = Project.get(request.context['project_id'])
-        self.binary = Binary.query.filter_by(name=binary_name, project=self.project).first()
+        self.distro_version = request.context['distro_version']
+        self.distro = request.context['distro']
+        self.ref = request.context['ref']
+        self.binary = Binary.query.filter_by(
+            name=binary_name,
+            ref=self.ref,
+            distro=self.distro,
+            distro_version=self.distro_version,
+            project=self.project).first()
 
     @expose(content_type='application/octet-stream', generic=True)
     def index(self):

--- a/chacra/tests/controllers/test_binaries.py
+++ b/chacra/tests/controllers/test_binaries.py
@@ -98,6 +98,18 @@ class TestBinaryController(object):
         )
         assert result.status_int == 200
 
+    def test_posting_twice__different_distro_ver_not_requires_force_flag(self, session, tmpdir):
+        pecan.conf.binary_root = str(tmpdir)
+        result = session.app.post(
+            '/projects/ceph/giant/ceph/el7/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/',
+            upload_files=[('file', 'ceph-9.0.0-0.el6.x86_64.rpm', 'hello tharrrr')]
+        )
+        result = session.app.post(
+            '/projects/ceph/giant/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/',
+            upload_files=[('file', 'ceph-9.0.0-0.el6.x86_64.rpm', 'hello tharrrr')]
+        )
+        assert result.status_int == 201
+
     def test_posting_twice_updates_the_binary(self, session, tmpdir):
         pecan.conf.binary_root = str(tmpdir)
         session.app.post(


### PR DESCRIPTION
So that a binary that gets posted with the same name is not flagged as "request is trying to modifying existing binary".

Endpoints make it unique.

Adds tests