### PR TITLE
A couple small tweaks

### DIFF
--- a/chacra/models/repos.py
+++ b/chacra/models/repos.py
@@ -31,7 +31,12 @@ class Repo(Base):
 
     def __repr__(self):
         try:
-            return '<Repo %r>' % self.name
+            return "<Repo {}/{}/{}/{}>".format(
+                self.project.name,
+                self.ref,
+                self.distro,
+                self.distro_version,
+            )
         except DetachedInstanceError:
             return '<Repo detached>'
 

--- a/config/dev.py
+++ b/config/dev.py
@@ -68,3 +68,6 @@ binary_root = '%(confdir)s/public'
 # When True it will set the headers so that Nginx can serve the download
 # instead of Pecan.
 delegate_downloads = False
+
+api_user = 'admin'
+api_key = 'secret'


### PR DESCRIPTION
Adds api_user an api_key to config/dev.py

Fixes ``chacra.models.repos.Repos.__repr__``