### PR TITLE
Adds POST functionality to /repos/project/ref/distro/distro_version/

### DIFF
--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -1,6 +1,10 @@
 from pecan import expose, abort, request
+from pecan.secure import secure
+from pecan.ext.notario import validate
+
 from chacra.models import Project
-from chacra.controllers import error
+from chacra.auth import basic_auth
+from chacra import schemas
 
 
 class RepoController(object):
@@ -23,7 +27,11 @@ class RepoController(object):
             abort(404)
         return self.repo
 
+    @secure(basic_auth)
     @index.when(method='POST', template='json')
+    @validate(schemas.repo_schema, handler='/errors/schema')
     def index_post(self):
-        error('/errors/not_allowed',
-              'POST requests to this url are not allowed')
+        data = request.json
+        for key in data:
+            setattr(self.repo, key, data[key])
+        return {}

--- a/chacra/schemas/__init__.py
+++ b/chacra/schemas/__init__.py
@@ -1,0 +1,9 @@
+from notario.validators import types
+from notario.decorators import optional
+
+repo_schema = (
+    (optional("distro"), types.string),
+    (optional("distro_version"), types.string),
+    (optional("needs_update"), types.boolean),
+    (optional("ref"), types.string),
+)

--- a/chacra/tests/controllers/repos/test_repos.py
+++ b/chacra/tests/controllers/repos/test_repos.py
@@ -57,3 +57,100 @@ class TestRepoApiController(object):
         session.commit()
         result = session.app.get('/repos/foobar/hammer/ubuntu/trusty/', expect_errors=True)
         assert result.status_int == 404
+
+    def test_update_single_field(self, session):
+        p = Project('foobar')
+        repo = Repo(
+            p,
+            "firefly",
+            "ubuntu",
+            "trusty",
+        )
+        repo.path = "some_path"
+        session.commit()
+        repo_id = repo.id
+        data = {"distro_version": "precise"}
+        result = session.app.post_json(
+            "/repos/foobar/firefly/ubuntu/trusty/",
+            params=data,
+        )
+        assert result.status_int == 200
+        updated_repo = Repo.get(repo_id)
+        assert updated_repo.distro_version == "precise"
+
+    def test_update_multiple_fields(self, session):
+        p = Project('foobar')
+        repo = Repo(
+            p,
+            "firefly",
+            "ubuntu",
+            "trusty",
+        )
+        repo.path = "some_path"
+        session.commit()
+        repo_id = repo.id
+        data = {"distro_version": "7", "distro": "centos"}
+        result = session.app.post_json(
+            "/repos/foobar/firefly/ubuntu/trusty/",
+            params=data,
+        )
+        assert result.status_int == 200
+        updated_repo = Repo.get(repo_id)
+        assert updated_repo.distro_version == "7"
+        assert updated_repo.distro == "centos"
+
+    def test_update_invalid_fields(self, session):
+        p = Project('foobar')
+        repo = Repo(
+            p,
+            "firefly",
+            "ubuntu",
+            "trusty",
+        )
+        repo.path = "some_path"
+        session.commit()
+        repo_id = repo.id
+        data = {"bogus": "7", "distro": "centos"}
+        result = session.app.post_json(
+            "/repos/foobar/firefly/ubuntu/trusty/",
+            params=data,
+            expect_errors=True,
+        )
+        assert result.status_int == 400
+        updated_repo = Repo.get(repo_id)
+        assert updated_repo.distro == "ubuntu"
+
+    def test_update_empty_json(self, session):
+        p = Project('foobar')
+        repo = Repo(
+            p,
+            "firefly",
+            "ubuntu",
+            "trusty",
+        )
+        repo.path = "some_path"
+        session.commit()
+        result = session.app.post_json(
+            "/repos/foobar/firefly/ubuntu/trusty/",
+            params=dict(),
+            expect_errors=True,
+        )
+        assert result.status_int == 400
+
+    def test_update_invalid_field_value(self, session):
+        p = Project('foobar')
+        repo = Repo(
+            p,
+            "firefly",
+            "ubuntu",
+            "trusty",
+        )
+        repo.path = "some_path"
+        session.commit()
+        data = {"distro": 123}
+        result = session.app.post_json(
+            "/repos/foobar/firefly/ubuntu/trusty/",
+            params=data,
+            expect_errors=True,
+        )
+        assert result.status_int == 400

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "pecan",
         "sqlalchemy",
         "psycopg2",
+        "pecan-notario",
     ],
     test_suite='chacra',
     zip_safe=False,


### PR DESCRIPTION
Updating the following fields are supported: distro, distro_version,
ref and needs_update.

This also includes validation of the endpoint using pecan-notario.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>