### PR TITLE
Refactor Binary.update_from_json into Base.update_from_json

### DIFF
--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -33,4 +33,4 @@ class RepoController(object):
     def index_post(self):
         data = request.json
         self.repo.update_from_json(data)
-        return {}
+        return self.repo

--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -32,6 +32,5 @@ class RepoController(object):
     @validate(schemas.repo_schema, handler='/errors/schema')
     def index_post(self):
         data = request.json
-        for key in data:
-            setattr(self.repo, key, data[key])
+        self.repo.update_from_json(data)
         return {}

--- a/chacra/models/__init__.py
+++ b/chacra/models/__init__.py
@@ -28,6 +28,14 @@ class _EntityBase(object):
         return dict((k, v) for k, v in self.__dict__.items()
                     if not k.startswith('_'))
 
+    def update_from_json(self, data):
+        """
+        We received a JSON blob with updated metadata information
+        that needs to update some fields
+        """
+        for key in data.keys():
+            setattr(self, key, data[key])
+
 
 Session = scoped_session(sessionmaker())
 metadata = MetaData()

--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -88,15 +88,6 @@ class Binary(Base):
         except DetachedInstanceError:
             return '<Binary detached>'
 
-    def update_from_json(self, data):
-        """
-        We received a JSON blob with updated metadata information
-        that needs to update some fields
-        """
-        for key in self.allowed_keys:
-            if key in data.keys():
-                setattr(self, key, data[key])
-
     @property
     def last_changed(self):
         if self.modified > self.created:

--- a/chacra/tests/controllers/repos/test_repos.py
+++ b/chacra/tests/controllers/repos/test_repos.py
@@ -77,6 +77,7 @@ class TestRepoApiController(object):
         assert result.status_int == 200
         updated_repo = Repo.get(repo_id)
         assert updated_repo.distro_version == "precise"
+        assert result.json['distro_version'] == "precise"
 
     def test_update_multiple_fields(self, session):
         p = Project('foobar')
@@ -98,6 +99,8 @@ class TestRepoApiController(object):
         updated_repo = Repo.get(repo_id)
         assert updated_repo.distro_version == "7"
         assert updated_repo.distro == "centos"
+        assert result.json['distro_version'] == "7"
+        assert result.json['distro'] == "centos"
 
     def test_update_invalid_fields(self, session):
         p = Project('foobar')


### PR DESCRIPTION
This lets us use that method for both binaries and repos.

Also returns self.repo from the repo api endpoint after an update has been performed and adds a couple tests to verify that returned json is correct.