### PR TITLE
adds a new celery role

### DIFF
--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -5,6 +5,7 @@
   roles:
     - common
     - repos
+    - celery
   vars:
      app_name: "chacra"
      use_ssl: true

--- a/deploy/playbooks/deploy_vagrant.yml
+++ b/deploy/playbooks/deploy_vagrant.yml
@@ -5,6 +5,7 @@
   roles:
     - common
     - repos
+    - celery
   vars:
      app_name: "chacra"
      use_ssl: true

--- a/deploy/playbooks/roles/celery/tasks/main.yml
+++ b/deploy/playbooks/roles/celery/tasks/main.yml
@@ -28,3 +28,9 @@
     name: rabbitmq-server
     state: started
     enabled: yes
+
+- name: ensure circus is running
+  sudo: yes
+  service:
+    name: circus
+    state: started 

--- a/deploy/playbooks/roles/celery/tasks/main.yml
+++ b/deploy/playbooks/roles/celery/tasks/main.yml
@@ -1,11 +1,9 @@
 ---
-- name: add rabbitmq official repo to sources.list
+- name: add the rabbitmq official repo
   sudo: yes
-  lineinfile:
-     dest: /etc/apt/sources.list 
-     regexp: '^deb http://www.rabbitmq.com/debian/ testing main'
-     line: 'deb http://www.rabbitmq.com/debian/ testing main'
-     backrefs: yes
+  apt_repository:
+    repo: "deb http://www.rabbitmq.com/debian/ testing main"
+    state: present
 
 - name: add the rabbitmq public key
   sudo: yes

--- a/deploy/playbooks/roles/celery/tasks/main.yml
+++ b/deploy/playbooks/roles/celery/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+
+- name: pip install celery
+  pip:
+    name: "celery[librabbitmq]"
+    virtualenv: "{{ app_home }}"
+    state: present
+
+- name: add rabbitmq official repo to sources.list
+  sudo: yes
+  lineinfile:
+     dest: /etc/apt/sources.list 
+     regexp: '^deb http://www.rabbitmq.com/debian/ testing main'
+     line: 'deb http://www.rabbitmq.com/debian/ testing main'
+     backrefs: yes
+
+- name: add the rabbitmq public key
+  sudo: yes
+  apt_key:
+    url: "https://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
+    state: present
+
+- name: update the apt cache
+  sudo: yes
+  apt:
+    update_cache: true
+
+- name: install rabbitmq-server
+  sudo: yes
+  apt:
+    name: rabbitmq-server
+    state: present
+
+- name: ensure rabbitmq is running and enabled
+  sudo: yes
+  service:
+    name: rabbitmq-server
+    state: started
+    enabled: yes

--- a/deploy/playbooks/roles/celery/tasks/main.yml
+++ b/deploy/playbooks/roles/celery/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-
-- name: pip install celery
-  pip:
-    name: "celery[librabbitmq]"
-    virtualenv: "{{ app_home }}"
-    state: present
-
 - name: add rabbitmq official repo to sources.list
   sudo: yes
   lineinfile:

--- a/deploy/playbooks/roles/common/templates/circus.ini.j2
+++ b/deploy/playbooks/roles/common/templates/circus.ini.j2
@@ -7,3 +7,16 @@ stdout_stream.filename=/var/log/circus/{{ app_name }}-stdout.log
 
 stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/{{ app_name }}-stderr.log
+
+[watcher:celery]
+cmd = {{ app_home }}/bin/celery -A async worker -B --loglevel=info
+working_dir={{ app_home }}/src/{{ app_name }}/{{ app_name }}
+
+stdout_stream.class = FileStream
+stdout_stream.filename=/var/log/celery/{{ app_name }}-stdout.log
+
+stderr_stream.class = FileStream
+stderr_stream.filename=/var/log/celery/{{ app_name }}-stderr.log
+
+[env:celery]
+PECAN_CONFIG = {{ app_home }}/src/{{ app_name }}/prod.py

--- a/deploy/playbooks/roles/common/vars/main.yml
+++ b/deploy/playbooks/roles/common/vars/main.yml
@@ -12,6 +12,8 @@ system_packages:
   - postgresql-contrib
   - python-psycopg2
   - nginx
+  # needed for the ansible apt_repository module
+  - python-apt
 #  - libsemanage-python
 
 ssl_requirements:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 psycopg2
 gunicorn
+pecan
+sqlalchemy
+pecan-notario
+celery[librabbitmq]


### PR DESCRIPTION
The role installs celery and rabbitmq, but does not start the celery workers.  We should probably use supervisord for that, I'll send another PR for that work.