### PR TITLE
run circusd as ansible_ssh_user

### DIFF
--- a/deploy/playbooks/roles/common/tasks/circus.yml
+++ b/deploy/playbooks/roles/common/tasks/circus.yml
@@ -12,6 +12,7 @@
     path: /etc/circus
     state: directory
     owner: "{{ ansible_ssh_user }}"
+    recurse: yes
   sudo: true
 
 - name: ensure /var/log/circus exists
@@ -19,6 +20,7 @@
     path: /var/log/circus
     state: directory
     owner: "{{ ansible_ssh_user }}"
+    recursive: yes
   sudo: true
 
 - name: ensure {{ app_home }}/log exists

--- a/deploy/playbooks/roles/common/tasks/circus.yml
+++ b/deploy/playbooks/roles/common/tasks/circus.yml
@@ -8,11 +8,17 @@
     - chaussette
 
 - name: ensure /etc/circus exists
-  file: path=/etc/circus state=directory
+  file:
+    path: /etc/circus
+    state: directory
+    owner: "{{ ansible_ssh_user }}"
   sudo: true
 
 - name: ensure /var/log/circus exists
-  file: path=/var/log/circus state=directory
+  file:
+    path: /var/log/circus
+    state: directory
+    owner: "{{ ansible_ssh_user }}"
   sudo: true
 
 - name: ensure {{ app_home }}/log exists

--- a/deploy/playbooks/roles/common/templates/circus.conf
+++ b/deploy/playbooks/roles/common/templates/circus.conf
@@ -1,2 +1,3 @@
 start on filesystem and net-device-up IFACE=lo
+setuid {{ ansible_ssh_user }}
 exec {{ app_home }}/bin/circusd /etc/circus/circus.ini

--- a/deploy/playbooks/roles/common/templates/circus.ini.j2
+++ b/deploy/playbooks/roles/common/templates/circus.ini.j2
@@ -1,3 +1,7 @@
+# the logging directories must be owned by the user that starts
+# the circusd daemon, which is set in /etc/init/circus.conf
+# we use a non-root user so that the celery workers start up correctly
+
 [watcher:{{ app_name }}]
 cmd = {{ app_home }}/bin/gunicorn_pecan -w 10 -t 300 prod.py
 working_dir={{ app_home }}/src/{{ app_name }}


### PR DESCRIPTION
We had to do this so that the celery workers would start. Before this
change circusd was running as root which made the celery workers try to
use root as well, which is not what we want.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>