### PR TITLE
api_key and api_user now use variables in the prod config

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -68,9 +68,8 @@ binary_root = "{{ binary_root }}"
 repos_root = "{{ repos_root }}"
 
 # Basic HTTP Auth credentials
-# FIXME
-api_user = False
-api_key = False
+api_user = "{{ api_user | default('admin') }}"
+api_key = "{{ api_key | default('secret') }}"
 
 # Celery options
 # How often (in seconds) the database should be queried for repos that need to


### PR DESCRIPTION
The disadvantage I see here is having to pass the api_key and api_user vars every time we deploy so we don't inadvertently reset prod to the defaults or something.

We might want to change this in the future so we don't need to do that.
