### PR TITLE
ansible: nginx config for HTTPS

### DIFF
--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -1,6 +1,11 @@
 server {
     listen       80;
+    listen       443 default_server ssl;
     server_name  localhost;
+
+    ssl_certificate     /etc/ssl/certs/{{ ansible_fqdn }}-bundled.crt;
+    ssl_certificate_key /etc/ssl/private/{{ ansible_fqdn }}.key;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
     access_log  /var/log/nginx/{{ app_name }}-access.log;
     error_log /var/log/nginx/{{ app_name }}-error.log;

--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -1,5 +1,4 @@
 server {
-    listen       80;
     listen       443 default_server ssl;
     server_name  localhost;
 


### PR DESCRIPTION
Add HTTPS to the chacra web server to protect authentication.

The key and certificate files are managed outside of Ansible.