### PR TITLE
ansible: set HSTS header in nginx

### DIFF
--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -5,6 +5,7 @@ server {
     ssl_certificate     /etc/ssl/certs/{{ ansible_fqdn }}-bundled.crt;
     ssl_certificate_key /etc/ssl/private/{{ ansible_fqdn }}.key;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    add_header Strict-Transport-Security "max-age=31536000";
 
     access_log  /var/log/nginx/{{ app_name }}-access.log;
     error_log /var/log/nginx/{{ app_name }}-error.log;


### PR DESCRIPTION
This will cause a browser to automatically load the "https://" URL when the user enters "chacra.ceph.com" into the browser.

Since we're not listening on port 80 any more, this change should make it a bit more user-friendly.

See https://www.owasp.org/index.php/HTTP_Strict_Transport_Security for more information