### PR TITLE
find all refs and distinct ones

### DIFF
--- a/chacra/tests/test_util.py
+++ b/chacra/tests/test_util.py
@@ -137,7 +137,7 @@ class TestGetExtraRepos(object):
             }
         }
         result = util.get_extra_repos('ceph', 'firefly',  repo_config=conf)
-        assert result == {'ceph-deploy': ['all']}
+        assert result == {'ceph-deploy': ['master']}
 
     def test_matching_project_ref_and_all_refs(self):
         # all versions of ceph-deploy for this repo, and just the 'firefly'

--- a/chacra/tests/test_util.py
+++ b/chacra/tests/test_util.py
@@ -139,6 +139,22 @@ class TestGetExtraRepos(object):
         result = util.get_extra_repos('ceph', 'firefly',  repo_config=conf)
         assert result == {'ceph-deploy': ['all']}
 
+    def test_matching_project_ref_and_all_refs(self):
+        # all versions of ceph-deploy for this repo, and just the 'firefly'
+        # release of ceph-release.
+        conf = {
+            'ceph': {
+                'all': {
+                    'ceph-deploy': ['all'],
+                },
+                'firefly': {
+                    'ceph-release': ['firefly']
+                    }
+                }
+            }
+        result = util.get_extra_repos('ceph', 'firefly',  repo_config=conf)
+        assert result == {'ceph-deploy': ['all'], 'ceph-release': ['firefly']}
+
 
 class TestCombined(object):
 

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -92,10 +92,22 @@ def get_extra_repos(project, ref=None, repo_config=None):
     if not project_config:
         logging.debug('%s has no configuration for extra repositories', project)
         return {}
-    extras = project_config.get(project_ref) or project_config.get('all', {})
-    if not extras:
+    # check first for 'all', if present, process that first:
+    all_refs = project_config.get('all', {})
+    distinct_ref = {}
+    # now check for a distinct ref if we were asked for one:
+    if ref is not None:
+        distinct_ref = project_config.get(ref, {})
+
+    # now that both have been check, combine them so that they can be processed
+    # as one large dictionary, note that key from distinct refs will be
+    # overwritten by 'all' refs, that is: 'all' has more importance than
+    # distinct, this is assumed as a configuration oversight by the user.
+    distinct_ref.update(all_refs)
+
+    if not distinct_ref:
         logger.warning('%s has no matching repositories for ref: %s', project, project_ref)
-    return extras
+    return distinct_ref
 
 
 def get_extra_binaries(project_name, distro, distro_version, distro_versions=None, ref=None):


### PR DESCRIPTION
This fixes a bug where a distinct ref would be chosen vs using both 'all' and the distinct one.

This happens when for example Ceph infernalis needs all versions of ceph-deploy in but just the infernalis version of ceph-release.