### PR TITLE
increase the prod polling_time and quiet_time

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -72,11 +72,11 @@ distributions_root = "%(confdir)s/distributions"
 # Celery options
 # How often (in seconds) the database should be queried for repos that need to
 # be rebuilt
-polling_cycle = 20
+polling_cycle = 60
 
 # Once a "create repo" task is called, how many seconds (if any) to wait before actually
 # creating the repository
-quiet_time = 5
+quiet_time = 20
 
 repos = {
     'ceph': {


### PR DESCRIPTION
This is to hopefully avoid a race condition where a .dsc file gets
uploaded before a .orig.tar.gz does and the repo fails to add the .dsc.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>