### PR TITLE
Safer recreate repo

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -82,6 +82,12 @@ def create_deb_repo(repo_id):
     # Determine paths for this repository
     paths = util.repo_paths(repo)
 
+    # Before doing work that might take very long to complete, set the repo
+    # path in the object and mark needs_update as False
+    repo.path = paths['absolute']
+    repo.needs_update = False
+    models.commit()
+
     # determine if other repositories might need to be queried to add extra
     # binaries (repos are tied to binaries which are all related with  refs,
     # archs, distros, and distro versions.
@@ -143,11 +149,6 @@ def create_deb_repo(repo_id):
             except subprocess.CalledProcessError:
                 logger.exception('failed to add binary %s', binary.name)
 
-    # Finally, set the repo path in the object and mark needs_update as False
-    repo.path = paths['absolute']
-    repo.needs_update = False
-    models.commit()
-
 
 @app.task(base=SQLATask)
 def create_rpm_repo(repo_id):
@@ -163,6 +164,12 @@ def create_rpm_repo(repo_id):
     # Determine paths for this repository
     paths = util.repo_paths(repo)
     repo_dirs = [os.path.join(paths['absolute'], d) for d in directories]
+
+    # Before doing work that might take very long to complete, set the repo
+    # path in the object and mark needs_update as False
+    repo.path = paths['absolute']
+    repo.needs_update = False
+    models.commit()
 
     # this is safe to do, behind the scenes it is just trying to create them if
     # they don't exist and it will include the 'absolute' path
@@ -196,11 +203,6 @@ def create_rpm_repo(repo_id):
 
     for d in repo_dirs:
         subprocess.check_call(['createrepo', d])
-
-    # Finally, set the repo path in the object and mark needs_update as False
-    repo.path = paths['absolute']
-    repo.needs_update = False
-    models.commit()
 
 
 app.conf.update(

--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -68,7 +68,10 @@ class RepoController(object):
             )
         # completely remove the path to the repository
         logger.info('removing repository path: %s', self.repo.path)
-        shutil.rmtree(self.repo.path)
+        try:
+            shutil.rmtree(self.repo.path)
+        except OSError:
+            logger.warning("could not remove repo path: %s", self.repo.path)
 
         # mark the repo so that celery picks it up
         self.repo.needs_update = True

--- a/chacra/tests/controllers/repos/test_repos.py
+++ b/chacra/tests/controllers/repos/test_repos.py
@@ -214,6 +214,25 @@ class TestRepoCRUDOperations(object):
         assert os.path.exists(path) is False
         assert result.json['needs_update'] is True
 
+    def test_recreate_invalid_path(self, session, tmpdir):
+        path = str(tmpdir)
+        invalid_path = os.path.join(path, 'invalid_path')
+        p = Project('foobar')
+        repo = Repo(
+            p,
+            "firefly",
+            "ubuntu",
+            "trusty",
+        )
+        repo.path = invalid_path
+        session.commit()
+        result = session.app.post_json(
+            "/repos/foobar/firefly/ubuntu/trusty/recreate",
+            params={}
+        )
+        assert os.path.exists(path) is True
+        assert result.json['needs_update'] is True
+
     def test_recreate_head(self, session, tmpdir):
         p = Project('foobar')
         repo = Repo(


### PR DESCRIPTION
And prevent dog-pilling work on creating repos by marking the repo as `needs_update = False` before doing anything else