### PR TITLE
Fix an issue that prevented combined repos from working

### DIFF
--- a/chacra/tests/test_util.py
+++ b/chacra/tests/test_util.py
@@ -240,6 +240,33 @@ class TestGetBinaries(object):
         result = util.get_extra_binaries('ceph', 'ubuntu', 'trusty', ref='master')
         assert len(result) == 1
 
+    def test_ref_matches_binaries_from_distro_versions(self, session):
+        models.Binary(
+            'ceph-1.0.deb',
+            self.p,
+            ref='firefly',
+            distro='ubuntu',
+            distro_version='precise',
+            arch='all',
+            )
+        models.Binary(
+            'ceph-1.0.deb',
+            self.p,
+            ref='firefly',
+            distro='ubuntu',
+            distro_version='trusty',
+            arch='all',
+            )
+
+        models.commit()
+        result = util.get_extra_binaries(
+            'ceph',
+            'ubuntu',
+            'trusty',
+            distro_versions=['precise', 'trusty'],
+            ref='firefly')
+        assert len(result) == 2
+
 
 class TestRepreproCommand(object):
 

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -139,10 +139,9 @@ def get_extra_binaries(project_name, distro, distro_version, distro_versions=Non
         for r in repo_query.all():
             binaries += [b for b in r.binaries]
     else:
-        # further filter by using ref, also return as a list
-        repo = repo_query.filter_by(ref=ref).first()
-        if repo:
-            binaries = [b for b in repo.binaries]
+        # further filter by using ref but looking for all matching repos
+        for r in repo_query.filter_by(ref=ref).all():
+            binaries += [b for b in r.binaries]
     logger.info('%d matched binaries found', len(binaries))
     return binaries
 


### PR DESCRIPTION
The use of `.first()` meant that if multiple repos where matched we would ignore them and use just the first one.

Adds a test to ensure the problem first and the fix later.