### PR TITLE
ansible: use fqdn for nginx server name

### DIFF
--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -1,6 +1,6 @@
 server {
     listen       443 default_server ssl;
-    server_name  localhost;
+    server_name  {{ ansible_fqdn }};
 
     ssl_certificate     /etc/ssl/certs/{{ ansible_fqdn }}-bundled.crt;
     ssl_certificate_key /etc/ssl/private/{{ ansible_fqdn }}.key;


### PR DESCRIPTION
Users will hit eg. "https://chacra.ceph.com/", not "https://localhost/". Set the `server_name` in our Nginx configuration to reflect this.