### PR TITLE
generic binary support for reprepro commands

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -144,11 +144,7 @@ def create_deb_repo(repo_id):
         except KeyError:  # probably a tar.gz or similar file that should not be added directly
             continue
         for command in commands:
-            try:
-                logger.info('running command: %s', ' '.join(command))
-            except TypeError:
-                logger.exception('was not able to add binary: %s', binary)
-                continue
+            logger.info('running command: %s', ' '.join(command))
             else:
                 try:
                     subprocess.check_call(command)

--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -145,11 +145,10 @@ def create_deb_repo(repo_id):
             continue
         for command in commands:
             logger.info('running command: %s', ' '.join(command))
-            else:
-                try:
-                    subprocess.check_call(command)
-                except subprocess.CalledProcessError:
-                    logger.exception('failed to add binary %s', binary.name)
+            try:
+                subprocess.check_call(command)
+            except subprocess.CalledProcessError:
+                logger.exception('failed to add binary %s', binary.name)
 
 
 @app.task(base=SQLATask)

--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -135,19 +135,23 @@ def create_deb_repo(repo_id):
         if binary.extension == 'changes':
             continue
         try:
-            command = util.reprepro_command(paths['absolute'], binary)
+            commands = util.reprepro_commands(
+                paths['absolute'],
+                binary,
+                distro_versions=combined_versions)
         except KeyError:  # probably a tar.gz or similar file that should not be added directly
             continue
-        try:
-            logger.info('running command: %s', ' '.join(command))
-        except TypeError:
-            logger.exception('was not able to add binary: %s', binary)
-            continue
-        else:
+        for command in commands:
             try:
-                subprocess.check_call(command)
-            except subprocess.CalledProcessError:
-                logger.exception('failed to add binary %s', binary.name)
+                logger.info('running command: %s', ' '.join(command))
+            except TypeError:
+                logger.exception('was not able to add binary: %s', binary)
+                continue
+            else:
+                try:
+                    subprocess.check_call(command)
+                except subprocess.CalledProcessError:
+                    logger.exception('failed to add binary %s', binary.name)
 
 
 @app.task(base=SQLATask)

--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -138,7 +138,9 @@ def create_deb_repo(repo_id):
             commands = util.reprepro_commands(
                 paths['absolute'],
                 binary,
-                distro_versions=combined_versions)
+                distro_versions=combined_versions,
+                fallback_version=repo.distro_version
+            )
         except KeyError:  # probably a tar.gz or similar file that should not be added directly
             continue
         for command in commands:

--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -109,6 +109,23 @@ class Binary(Base):
             last = self.created
         return util.last_seen(last)
 
+    @property
+    def is_generic(self):
+        """
+        Generic binaries are built without a specific target distribution version. They should
+        work in any version/release which requires the repository-creation mechanism to special case
+        them as repositories may be combined and require us to add them to different distributions.
+        Specifically, we match the distro version to:
+
+        * generic
+        * universal
+        * any
+        """
+        target_versions = ['generic', 'universal', 'any']
+        if self.distro_version in target_versions:
+            return True
+        return False
+
     def __json__(self):
         return dict(
             name=self.name,

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -252,3 +252,41 @@ def reprepro_command(repository_path, binary, distro_version=None):
         include_flag, distro_version,
         binary.path
     ]
+
+
+def reprepro_commands(repository_path, binary, distro_versions=None):
+    """
+    When a generic (non-distro-version-specific) DEB binary is built it can't
+    be added with reprepro as-is because internal chacra mechanisms infer the
+    distro version of the repo looking into the metadata associated with the
+    binary.
+
+    A binary like ceph-deploy_1.5.30_all.deb that lives in a path like
+    ceph-deploy/master/debian/universal/all/ will generate a reprepro command
+    that attempts to add the binary to a repo using "universal" as the distro
+    version, which doesn't exist.
+
+    This is only a problem with generic binaries, so this helper function will
+    try to detect this by matching the distro version to a few values allowed
+    for generic builds:
+
+    * generic
+    * universal
+    * any
+
+
+    Instead of returning a single command (as a list so that it can be consumed
+    with Popen) it will return all possible commands if ``distro_versions`` is
+    used or just a single item in a list if none are passed.
+    """
+    commands = []
+    distro_versions = distro_versions or [binary.distro_version]
+    for distro_version in distro_versions:
+        commands.append(
+            reprepro_command(
+                repository_path,
+                binary,
+                distro_version=distro_version
+            )
+        )
+    return commands

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -249,6 +249,6 @@ def reprepro_command(repository_path, binary, distro_version=None):
         '--ignore=wrongdistribution',
         '--ignore=wrongversion',
         '--ignore=undefinedtarget',
-        include_flag, binary.distro_version,
+        include_flag, distro_version,
         binary.path
     ]

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -225,13 +225,14 @@ def reprepro_confdir(project_name):
     return confdir_path
 
 
-def reprepro_command(repository_path, binary):
+def reprepro_command(repository_path, binary, distro_version=None):
     """
-    Depending on the filetype we are dealin the reprepro command will need to
+    Depending on the filetype we are dealing the reprepro command will need to
     change to accommodate for its inclusion in a DEB repository. This is
     specifically meant to handle both .dsc and .changes files which need to be
     treaded differently.
     """
+    distro_version = distro_version or binary.distro_version
     include_flags = {
         'deb': 'includedeb',
         'dsc': 'includedsc',

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -95,11 +95,9 @@ repos = {
         'testing': {
             'ceph': ['jewel-rc'],
         },
-        # 'universal' is a naming convention used by the Ceph CI to build DEB
-        # binaries that are not distro-version-dependant. That is: they are
-        # built in some Debian/Ubuntu box but they can work on any since they
-        # are not tied to the distribution version.
-        'combined': ['wheezy', 'trusty', 'precise', 'universal']
+        # note: 'universal' binaries will be included to all these distro
+        # versions since they do not belong to any one in particular.
+        'combined': ['wheezy', 'trusty', 'precise']
    },
     '__force_dict__': True,
 }


### PR DESCRIPTION
This is very well documented in the docstrings, but mainly we are now generating a bunch of `reprepro` commands because a generic binary might need to be 'added' to different distro version combinations