### PR TITLE
Better search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ logical operators can be used, like ``>=`` for example.
 
 In its most simple form a query would look like::
 
-    /search/?name=ceph
+    /search/?name=ceph_10.0.0_el6.x86_64.rpm
 
 Successful responses will return an array of items found along with metadata
 about locations.

--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,8 @@ In its most simple form a query would look like::
 
     /search/?name=ceph
 
-Search terms don't need to be unique and successful responses will return an
-array of items found along with metadata about locations.
+Successful responses will return an array of items found along with metadata
+about locations.
 
 The supported query parameters are:
 
@@ -137,6 +137,18 @@ The supported query parameters are:
 * ``built_by``
 * ``size``
 * ``name``
+
+These require to have exact matches. For example a query like
+``?distro=CentOS`` would not return binaries that have a ``centos`` distro
+value.
+
+Search terms that allow more flexiblity are:
+
+* ``name-has``
+
+The ``-has`` connotation means that any part of the binary name (in this case)
+can have that value. For example a query like ``?name-has=deploy`` would match
+a binary like ``ceph-deploy_1.5.21_all.deb``.
 
 
 HTTP Responses:

--- a/chacra/controllers/search.py
+++ b/chacra/controllers/search.py
@@ -14,7 +14,7 @@ class SearchController(object):
                 'built_by': Binary.built_by,
                 'size': Binary.size,
                 'name': Binary.name,
-                'name-like': Binary.name.like,
+                'name-has': Binary.name.like,
         }
 
     @expose('json')
@@ -36,15 +36,15 @@ class SearchController(object):
 
     def filter_binary(self, key, value, query=None):
         filter_obj = self.filters[key]
-        # for *-like search only
+        # for *-has search only
         search_value = '%{value}%'.format(value=value)
 
         # query will exist if multiple filters are being applied, e.g. by name
         # and by distro but otherwise it will be None
         if query:
-            if key.endswith('-like'):
+            if key.endswith('-has'):
                 return query.filter(filter_obj(search_value))
             return query.filter(filter_obj == value)
-        if key.endswith('-like'):
+        if key.endswith('-has'):
             return Binary.query.filter(filter_obj(search_value))
         return Binary.query.filter(filter_obj == value)

--- a/chacra/tests/controllers/test_search.py
+++ b/chacra/tests/controllers/test_search.py
@@ -1,6 +1,7 @@
 import pecan
 import os
 from chacra.models import Project, Binary
+from chacra.controllers import search
 
 
 class TestSearchController(object):
@@ -37,3 +38,18 @@ class TestSearchController(object):
         session.commit()
         result = session.app.get('/search/?distro=centos')
         assert len(result.json) == 2
+
+
+class TestLikeSearch(object):
+
+    def setup(self):
+        self.controller = search.SearchController()
+
+    def test_search_like_name(self, session):
+        project = Project('ceph')
+        Binary('ceph-1.0.0.rpm', project, ref='giant', distro='centos', distro_version='el6', arch='x86_64')
+        Binary('radosgw-agent-1.0.0.rpm', project, ref='giant', distro='centos', distro_version='el7', arch='x86_64')
+        session.commit()
+        result = session.app.get('/search/?name-like=ceph')
+        assert len(result.json) == 1
+        assert result.json[0]['name'] == 'ceph-1.0.0.rpm'

--- a/chacra/tests/controllers/test_search.py
+++ b/chacra/tests/controllers/test_search.py
@@ -50,6 +50,6 @@ class TestLikeSearch(object):
         Binary('ceph-1.0.0.rpm', project, ref='giant', distro='centos', distro_version='el6', arch='x86_64')
         Binary('radosgw-agent-1.0.0.rpm', project, ref='giant', distro='centos', distro_version='el7', arch='x86_64')
         session.commit()
-        result = session.app.get('/search/?name-like=ceph')
+        result = session.app.get('/search/?name-has=ceph')
         assert len(result.json) == 1
         assert result.json[0]['name'] == 'ceph-1.0.0.rpm'


### PR DESCRIPTION
because it will allow to use `name-like=ceph` and get proper results. Otherwise users are forced to have the exact name they are looking for

Fixes issue #80 