### PR TITLE
include jessie when combining repos

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -153,7 +153,7 @@ def create_deb_repo(repo_id):
 
     all_binaries = extra_binaries + [b for b in repo.binaries]
 
-    for binary in all_binaries:
+    for binary in set(all_binaries):
         # XXX This is really not a good alternative but we are not going to be
         # using .changes for now although we can store it.
         if binary.extension == 'changes':

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -97,7 +97,7 @@ repos = {
         },
         # note: 'universal' binaries will be included to all these distro
         # versions since they do not belong to any one in particular.
-        'combined': ['wheezy', 'trusty', 'precise']
+        'combined': ['wheezy', 'trusty', 'precise', 'jessie']
    },
     '__force_dict__': True,
 }


### PR DESCRIPTION
This was causing that generic binaries wouldn't be included in jessie repos.

It also adds a `set()` call to ensure we are not overloading reprepro for no good reason.