### PR TITLE
mark related repositories for update

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -80,6 +80,7 @@ def create_deb_repo(repo_id):
     logger.info("processing repository: %s", repo)
     if util.repository_is_disabled(repo.project.name):
         logger.info("will not process repository: %s", repo)
+        repo.needs_update = False
         return
 
     # Determine paths for this repository
@@ -187,6 +188,7 @@ def create_rpm_repo(repo_id):
     logger.info("processing repository: %s", repo)
     if util.repository_is_disabled(repo.project.name):
         logger.info("will not process repository: %s", repo)
+        repo.needs_update = False
         return
 
     # Determine paths for this repository

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -101,6 +101,8 @@ class ArchController(object):
         repos = []
         for project_name, refs in related_projects.items():
             p = models.Project.filter_by(name=project_name).first()
+            if not p:
+                p = models.Project(name=project_name)
             repo_query = []
             if refs == ['all']:
                 # we need all the repos available
@@ -116,7 +118,7 @@ class ArchController(object):
             # there are no repositories associated with this project, so go ahead
             # and create one so that it can be queried by the celery task later
             repo = models.Repo(
-                self.project,
+                p,
                 self.ref,
                 self.distro,
                 self.distro_version

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -101,9 +101,7 @@ class ArchController(object):
         repos = []
         projects = []
         for project_name, refs in related_projects.items():
-            p = models.Project.filter_by(name=project_name).first()
-            if not p:
-                p = models.Project(name=project_name)
+            p = models.projects.get_or_create(name=project_name)
             projects.append(p)
             repo_query = []
             if refs == ['all']:

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -5,7 +5,7 @@ from pecan import response
 from pecan.secure import secure
 from pecan import expose, abort, request
 from chacra.models import Binary
-from chacra import models
+from chacra import models, util
 from chacra.controllers import error
 from chacra.controllers.binaries import BinaryController
 from chacra.auth import basic_auth
@@ -94,6 +94,39 @@ class ArchController(object):
             )
         else:
             self.binary.path = full_path
+
+        # check if this binary is interesting for other configured projects,
+        # and if so, then mark those other repos so that they can be re-built
+        related_projects = util.get_related_projects(self.project.name)
+        repos = []
+        for project_name, refs in related_projects.items():
+            p = models.Project.filter_by(name=project_name).first()
+            repo_query = []
+            if refs == ['all']:
+                # we need all the repos available
+                repo_query = models.Repo.filter_by(project=p).all()
+            else:
+                for ref in refs:
+                    repo_query = models.Repo.filter_by(project=p, ref=ref).all()
+            if repo_query:
+                for r in repo_query:
+                    repos.append(r)
+
+        if not repos:
+            # there are no repositories associated with this project, so go ahead
+            # and create one so that it can be queried by the celery task later
+            repo = models.Repo(
+                self.project,
+                self.ref,
+                self.distro,
+                self.distro_version
+            )
+            repo.needs_update = True
+
+        else:
+            for repo in repos:
+                repo.needs_update = True
+
         return dict()
 
     def create_directory(self):

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -99,10 +99,12 @@ class ArchController(object):
         # and if so, then mark those other repos so that they can be re-built
         related_projects = util.get_related_projects(self.project.name)
         repos = []
+        projects = []
         for project_name, refs in related_projects.items():
             p = models.Project.filter_by(name=project_name).first()
             if not p:
                 p = models.Project(name=project_name)
+            projects.append(p)
             repo_query = []
             if refs == ['all']:
                 # we need all the repos available
@@ -117,13 +119,14 @@ class ArchController(object):
         if not repos:
             # there are no repositories associated with this project, so go ahead
             # and create one so that it can be queried by the celery task later
-            repo = models.Repo(
-                p,
-                self.ref,
-                self.distro,
-                self.distro_version
-            )
-            repo.needs_update = True
+            for project in projects:
+                repo = models.Repo(
+                    project,
+                    self.ref,
+                    self.distro,
+                    self.distro_version
+                )
+                repo.needs_update = True
 
         else:
             for repo in repos:

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -97,6 +97,11 @@ class ArchController(object):
 
         # check if this binary is interesting for other configured projects,
         # and if so, then mark those other repos so that they can be re-built
+        self.mark_related_repos()
+
+        return dict()
+
+    def mark_related_repos(self):
         related_projects = util.get_related_projects(self.project.name)
         repos = []
         projects = []
@@ -129,8 +134,6 @@ class ArchController(object):
         else:
             for repo in repos:
                 repo.needs_update = True
-
-        return dict()
 
     def create_directory(self):
         end_part = request.url.split('binaries/')[-1].rstrip('/')

--- a/chacra/models/projects.py
+++ b/chacra/models/projects.py
@@ -60,3 +60,10 @@ class Project(Base):
                 )
             )
         return json_
+
+
+def get_or_create(name, **kw):
+    project = Project.filter_by(name=name).first()
+    if not project:
+        project = Project(name=name)
+    return project

--- a/chacra/tests/test_util.py
+++ b/chacra/tests/test_util.py
@@ -479,3 +479,40 @@ class TestRepositoryIsDisabled(object):
     def test_repo_configured_but_not_project(self):
         pecan.conf.repos = {'foo': {'disabled': True}}
         assert util.repository_is_disabled('bar') is False
+
+
+class TestRelatedProjects(object):
+
+    def setup(self):
+        self.conf = dict()
+
+    def test_nothing_is_related(self):
+        self.conf['ceph'] = {
+            'firefly': {'ceph-deploy': ['all']}
+        }
+        result = util.get_related_projects('radosgw-agent', repo_config=self.conf)
+        assert result == {}
+
+    def test_project_is_related_with_distinct_refs(self):
+        self.conf['ceph'] = {
+            'firefly': {'ceph-deploy': ['all']}
+        }
+        result = util.get_related_projects('ceph-deploy', repo_config=self.conf)
+        assert result == {'ceph': ['firefly']}
+
+    def test_project_is_related_with_all_refs(self):
+        self.conf['ceph'] = {
+            'all': {'ceph-deploy': ['master']},
+            'firefly': {'ceph-release': ['firefly']}
+        }
+        result = util.get_related_projects('ceph-deploy', repo_config=self.conf)
+        assert result == {'ceph': ['all']}
+
+    def test_project_is_related_multiple_refs(self):
+        self.conf['ceph'] = {
+            'hammer': {'ceph-deploy': ['master']},
+            'firefly': {'ceph-deploy': ['master']}
+        }
+        result = util.get_related_projects('ceph-deploy', repo_config=self.conf)
+        assert sorted(result['ceph']) == sorted(['hammer',  'firefly'])
+

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -72,6 +72,9 @@ def get_related_projects(project, repo_config=None):
         project_configuration = repo_config[project_name]
         project_refs = project_configuration.keys()
         for project_ref in project_refs:
+            # 'combined' is not a ref, it is an option
+            if project_ref == 'combined':
+                continue
             ref_configuration = project_configuration[project_ref]
             related_projects = ref_configuration.keys()
             if project in related_projects:

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import os
 import errno
 import logging
@@ -56,6 +57,34 @@ def repo_paths(repo):
     paths['absolute'] = os.path.join(paths['root'], paths['relative'])
 
     return paths
+
+
+def get_related_projects(project, repo_config=None):
+    """
+    Find out if ``project`` of a given ``ref`` might be needed in repositories
+    for other projects (defined via configuration).
+    """
+    matches = defaultdict(list)
+    repo_config = repo_config or getattr(conf, 'repos', {})
+    if not repo_config:
+        return {}
+    for project_name in repo_config.keys():
+        project_configuration = repo_config[project_name]
+        project_refs = project_configuration.keys()
+        for project_ref in project_refs:
+            ref_configuration = project_configuration[project_ref]
+            related_projects = ref_configuration.keys()
+            if project in related_projects:
+                if project_ref == 'all':
+                    matches[project_name] = ['all']
+                    # no need to continue because we need to use all
+                    # refs
+                    break
+                else:
+                    # otherwise append it, we might have other distinct refs
+                    # we care about
+                    matches[project_name].append(project_ref)
+    return matches
 
 
 def get_combined_repos(project, repo_config=None):


### PR DESCRIPTION
This PR addresses the issue of POSTing a new binary and not triggering a repository build (or update) for a related project.

For example if a ceph-deploy binary, that is configured to get included in the ceph project repos is POSTed, chacra will now understand that a relationship exists and will mark the corresponding repositories for the ceph project to get updated.

If configuration exists for a new project that hasn't been created yet, this PR will address the problem of creating that project and the repository model objects as well.