### PR TITLE
infer repo type

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -64,7 +64,14 @@ def poll_repos():
                     (r.id,),
                     countdown=pecan.conf.quiet_time)
             else:
-                logger.warning('got a repository with an unkown type: %s', r)
+                _type = r.infer_type()
+                if _type is None:
+                    logger.warning('failed to infer repository type')
+                    logger.warning('got a repository with an unknown type: %s', r)
+                else:
+                    logger.warning('inferred repo type as: %s', _type)
+                    r.type = _type
+                    models.commit()
 
     logger.info('completed repo polling')
 

--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -88,6 +88,7 @@ def create_deb_repo(repo_id):
     if util.repository_is_disabled(repo.project.name):
         logger.info("will not process repository: %s", repo)
         repo.needs_update = False
+        models.commit()
         return
 
     # Determine paths for this repository

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -87,7 +87,7 @@ class ArchController(object):
             arch = request.context['arch']
             ref = request.context['ref']
 
-            Binary(
+            self.binary = Binary(
                 self.binary_name, self.project, arch=arch,
                 distro=distro, distro_version=distro_version,
                 ref=ref, path=path, size=os.path.getsize(path)
@@ -130,10 +130,13 @@ class ArchController(object):
                     self.distro_version
                 )
                 repo.needs_update = True
+                repo.type = self.binary._get_repo_type()
 
         else:
             for repo in repos:
                 repo.needs_update = True
+                if repo.type is None:
+                    repo.type = self.binary._get_repo_type()
 
     def create_directory(self):
         end_part = request.url.split('binaries/')[-1].rstrip('/')

--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -60,18 +60,22 @@ class Binary(Base):
     def extension(self):
         return self.name.split('.')[-1]
 
-    def _set_repo_type(self):
+    def _get_repo_type(self):
         extension_map = {
             'rpm': 'rpm',
             'deb': 'deb',
             'dsc': 'deb',
             'changes': 'deb'
         }
+
+        # XXX This is very naive, but 'deb' repos are the only ones that
+        # will have .tar or .tar.gz or just .gz extensions for source
+        # files, so fallback to that
+        return extension_map.get(self.extension, 'deb')
+
+    def _set_repo_type(self):
         if self.repo.type is None:
-            # XXX This is very naive, but 'deb' repos are the only ones that
-            # will have .tar or .tar.gz or just .gz extensions for source
-            # files, so fallback to that
-            self.repo.type = extension_map.get(self.extension, 'deb')
+            self.repo.type = self._get_repo_type()
 
     def _get_or_create_repo(self):
         """

--- a/chacra/models/repos.py
+++ b/chacra/models/repos.py
@@ -60,6 +60,14 @@ class Repo(Base):
                 return True
         return False
 
+    def infer_type(self):
+        """
+        Sometimes a repo may not know what 'type' it is (a deb or rpm)
+        so this goes looking at its binaries for an answer
+        """
+        for binary in self.binaries:
+            return binary._get_repo_type()
+
 
 # listen for timestamp modifications
 listen(Repo, 'before_insert', update_timestamp)

--- a/chacra/tests/controllers/test_binaries.py
+++ b/chacra/tests/controllers/test_binaries.py
@@ -356,3 +356,19 @@ class TestRelatedProjects(object):
         rhcs_project = Project.filter_by(name='rhcs').first()
         assert Repo.filter_by(project=ceph_project).first().needs_update is True
         assert Repo.filter_by(project=rhcs_project).first().needs_update is True
+
+    def test_marks_nonexsitent_related_project_type(self, session, tmpdir):
+        pecan.conf.binary_root = str(tmpdir)
+        pecan.conf.repos = {
+            'ceph': {
+                'all': {'ceph-deploy': ['master']}
+            },
+            '__force_dict__': True,
+        }
+        session.app.post(
+            '/binaries/ceph-deploy/master/centos/6/x86_64/',
+            upload_files=[('file', 'ceph-deploy_9.0.0-0.el6.x86_64.rpm', 'hello tharrrr')]
+        )
+        project = Project.filter_by(name='ceph').first()
+        repo = Repo.filter_by(project=project).first()
+        assert repo.type == 'rpm'

--- a/chacra/tests/models/test_repos.py
+++ b/chacra/tests/models/test_repos.py
@@ -1,4 +1,4 @@
-from chacra.models import Project, Repo
+from chacra.models import Project, Repo, Binary
 
 
 class TestRepoModification(object):
@@ -38,3 +38,33 @@ class TestRepoModification(object):
             distro_version='7',
             )
         assert repo.is_generic is False
+
+
+class TestInferType(object):
+
+    def setup(self):
+        self.p = Project('ceph')
+
+    def test_rpm_is_inferred(self, session):
+        binary = Binary(
+            'ceph-1.0.rpm',
+            self.p,
+            distro='centos',
+            distro_version='7',
+            arch='x86_64',
+            )
+        session.commit()
+        repo = Repo.get(1)
+        assert repo.infer_type() == 'rpm'
+
+    def test_deb_is_inferred(self, session):
+        binary = Binary(
+            'ceph-1.0.deb',
+            self.p,
+            distro='ubuntu',
+            distro_version='trusty',
+            arch='x86_64',
+            )
+        session.commit()
+        repo = Repo.get(1)
+        assert repo.infer_type() == 'deb'


### PR DESCRIPTION
There are situations where *related* repos that are created because of a configured relationship might not have the type set.

This PR fixes this so that at creation time if the Repo does not exist the type will be set.