### PR TITLE
Fix timeouts (thanks to ceph-debuginfo)

### DIFF
--- a/deploy/playbooks/roles/common/templates/circus.ini.j2
+++ b/deploy/playbooks/roles/common/templates/circus.ini.j2
@@ -22,6 +22,36 @@ stdout_stream.filename=/var/log/circus/celery-stdout.log
 stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/celery-stderr.log
 
+[watcher:celery-worker2]
+cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker2.%h
+working_dir=/opt/chacra/src/chacra/chacra
+
+stdout_stream.class = FileStream
+stdout_stream.filename=/var/log/circus/celery-stdout2.log
+
+stderr_stream.class = FileStream
+stderr_stream.filename=/var/log/circus/celery-stderr2.log
+
+[watcher:celery-worker3]
+cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker3.%h
+working_dir=/opt/chacra/src/chacra/chacra
+
+stdout_stream.class = FileStream
+stdout_stream.filename=/var/log/circus/celery-stdout.log
+
+stderr_stream.class = FileStream
+stderr_stream.filename=/var/log/circus/celery-stderr.log
+
+[watcher:celery-worker4]
+cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker4.%h
+working_dir=/opt/chacra/src/chacra/chacra
+
+stdout_stream.class = FileStream
+stdout_stream.filename=/var/log/circus/celery-stdout.log
+
+stderr_stream.class = FileStream
+stderr_stream.filename=/var/log/circus/celery-stderr.log
+
 [watcher:celerybeat]
 cmd = {{ app_home }}/bin/celery -A async beat --loglevel=info
 working_dir={{ app_home }}/src/{{ app_name }}/{{ app_name }}
@@ -32,5 +62,5 @@ stdout_stream.filename=/var/log/circus/celerybeat-stdout.log
 stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/celerybeat-stderr.log
 
-[env:celery,celerybeat]
+[env:celery,celery-worker2,celery-worker3,celery-worker4,celerybeat]
 PECAN_CONFIG = {{ app_home }}/src/{{ app_name }}/prod.py

--- a/deploy/playbooks/roles/common/templates/circus.ini.j2
+++ b/deploy/playbooks/roles/common/templates/circus.ini.j2
@@ -3,7 +3,7 @@
 # we use a non-root user so that the celery workers start up correctly
 
 [watcher:{{ app_name }}]
-cmd = {{ app_home }}/bin/gunicorn_pecan -w 10 -t 300 prod.py
+cmd = {{ app_home }}/bin/gunicorn_pecan -w 10 -t 500 prod.py
 working_dir={{ app_home }}/src/{{ app_name }}
 
 stdout_stream.class = FileStream

--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -10,8 +10,8 @@ server {
     access_log  /var/log/nginx/{{ app_name }}-access.log;
     error_log /var/log/nginx/{{ app_name }}-error.log;
 
-
-    client_max_body_size 1024m;
+    # Some binaries are gigantic
+    client_max_body_size 2048m;
 
     location / {
       proxy_set_header        Host $host;
@@ -20,7 +20,7 @@ server {
       proxy_set_header        X-Forwarded-Proto $scheme;
 
       proxy_pass          http://127.0.0.1:8000;
-      proxy_read_timeout  300;
+      proxy_read_timeout  500;
     }
 
 


### PR DESCRIPTION
This bumps the timeouts for both nginx and gunicorn, it also bumps the max size allowed to 2GB, and finally it adds 3 more workers to celery.