### PR TITLE
prevent distros from polluting other refs

### DIFF
--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -30,14 +30,17 @@ class ArchController(object):
 
     @index.when(method='HEAD', template='json')
     def index_head(self):
-        if self.arch not in self.project.archs:
+        binaries = self.project.binaries.filter_by(
+            distro=self.distro,
+            distro_version=self.distro_version,
+            ref=self.ref,
+            arch=self.arch).all()
+
+        if not binaries:
             abort(404)
 
     @index.when(method='GET', template='json')
     def index_get(self):
-        if self.arch not in self.project.archs:
-            abort(404)
-
         binaries = self.project.binaries.filter_by(
             distro=self.distro,
             distro_version=self.distro_version,

--- a/chacra/controllers/binaries/distros.py
+++ b/chacra/controllers/binaries/distros.py
@@ -52,17 +52,15 @@ class DistroController(object):
 
     @expose('json', generic=True)
     def index(self):
-        # TODO: Improve this duplication here (and spread to other controllers)
-        if self.distro_name not in self.project.distros:
-            abort(404)
-        if self.ref not in self.project.refs:
-            abort(404)
         resp = {}
 
         binaries = models.Binary.filter_by(
             project=self.project,
             distro=self.distro_name,
             ref=self.ref).all()
+
+        if not binaries:
+            abort(404)
 
         distro_versions = set([b.distro_version for b in binaries])
 


### PR DESCRIPTION
By relying on database queries with as much information available as possible.