### PR TITLE
Distinct queues for polling and building repos

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -62,11 +62,15 @@ def poll_repos():
             if r.type == 'rpm':
                 create_rpm_repo.apply_async(
                     (r.id,),
-                    countdown=pecan.conf.quiet_time)
+                    countdown=pecan.conf.quiet_time,
+                    queue='build_repos',
+                    )
             elif r.type == 'deb':
                 create_deb_repo.apply_async(
                     (r.id,),
-                    countdown=pecan.conf.quiet_time)
+                    countdown=pecan.conf.quiet_time,
+                    queue='build_repos',
+                    )
             else:
                 _type = r.infer_type()
                 if _type is None:

--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -264,6 +264,7 @@ app.conf.update(
             'task': 'async.poll_repos',
             'schedule': timedelta(
                 seconds=pecan.conf.polling_cycle),
+            'options': {'queue' : 'poll_repos'}
         },
     },
 )

--- a/deploy/playbooks/roles/common/handlers/main.yml
+++ b/deploy/playbooks/roles/common/handlers/main.yml
@@ -4,7 +4,21 @@
   command: "{{ app_home }}/bin/circusctl restart {{ app_name }}"
 
 - name: restart celery
-  command: "{{ app_home }}/bin/circusctl restart celery celery-worker2 celery-worker3 celery-worker4"
+  command: "{{ app_home }}/bin/circusctl restart celery"
+  register: celery_worker
+
+- name: "restart celery worker 2"
+  command: "{{ app_home }}/bin/circusctl restart celery-worker2"
+  register: celery_worker_2
+  when: celery_worker.changed
+
+- name: "restart celery worker 3"
+  command: "{{ app_home }}/bin/circusctl restart celery-worker3"
+  when: celery_worker_2.changed
+
+- name: "restart celery worker 4"
+  command: "{{ app_home }}/bin/circusctl restart celery-worker4"
+  when: celery_worker_3.changed
 
 - name: restart celery beat
   command: "{{ app_home }}/bin/circusctl restart celerybeat"

--- a/deploy/playbooks/roles/common/templates/circus.ini.j2
+++ b/deploy/playbooks/roles/common/templates/circus.ini.j2
@@ -13,7 +13,7 @@ stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/{{ app_name }}-stderr.log
 
 [watcher:celery]
-cmd = {{ app_home }}/bin/celery -A async worker --loglevel=info
+cmd = {{ app_home }}/bin/celery -A async worker --loglevel=info -Q poll_repos
 working_dir={{ app_home }}/src/{{ app_name }}/{{ app_name }}
 
 stdout_stream.class = FileStream
@@ -23,7 +23,7 @@ stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/celery-stderr.log
 
 [watcher:celery-worker2]
-cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker2.%h
+cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker2.%h -Q build_repos
 working_dir=/opt/chacra/src/chacra/chacra
 
 stdout_stream.class = FileStream
@@ -33,7 +33,7 @@ stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/celery-stderr2.log
 
 [watcher:celery-worker3]
-cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker3.%h
+cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker3.%h -Q build_repos
 working_dir=/opt/chacra/src/chacra/chacra
 
 stdout_stream.class = FileStream
@@ -43,7 +43,7 @@ stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/celery-stderr.log
 
 [watcher:celery-worker4]
-cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker4.%h
+cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker4.%h -Q build_repos
 working_dir=/opt/chacra/src/chacra/chacra
 
 stdout_stream.class = FileStream


### PR DESCRIPTION
To further avoid dog-pilling because all workers will try to build repos and "polling" comes along and queues itself (up to ~7K items at one point).

This also fixes the issue of failing to restart celery workers