### PR TITLE
Fix parent projects being related to themselves 

### DIFF
--- a/chacra/util.py
+++ b/chacra/util.py
@@ -84,9 +84,13 @@ def get_related_projects(project, repo_config=None):
                     # refs
                     break
                 else:
-                    # otherwise append it, we might have other distinct refs
-                    # we care about
-                    matches[project_name].append(project_ref)
+                    # otherwise append it, we might have other distinct refs we
+                    # care about. Take special care of avoiding a circular
+                    # reference by not including the same related project as
+                    # the parent one.
+
+                    if project != project_name:
+                        matches[project_name].append(project_ref)
     return matches
 
 


### PR DESCRIPTION
Due to the odd way of Ceph composing repos we had to configure the app to accommodate for the same project name ('ceph') using a distinct ref ('jewel-rc') to be added to a ref ('testing') belonging to the same project name ('ceph' again).

The utility affected is used by the controller that accepts POST requests for new binaries that will also mark repos as `needs_update=True`, which will cause massive dog-pilling with the circular reference.