### PR TITLE
Don't read large binaries at once

### DIFF
--- a/chacra/controllers/binaries/__init__.py
+++ b/chacra/controllers/binaries/__init__.py
@@ -178,7 +178,11 @@ class BinaryController(object):
             response.status = 201
 
         destination = os.path.join(dir_path, self.binary_name)
+
         with open(destination, 'wb') as f:
-            f.write(file_obj.read())
+            file_iterable = FileIter(file_obj)
+            for chunk in file_iterable:
+                f.write(chunk)
+
         # return the full path to the saved object:
         return destination

--- a/chacra/controllers/binaries/__init__.py
+++ b/chacra/controllers/binaries/__init__.py
@@ -179,9 +179,6 @@ class BinaryController(object):
 
         destination = os.path.join(dir_path, self.binary_name)
         with open(destination, 'wb') as f:
-            try:
-                f.write(file_obj.getvalue())
-            except AttributeError:
-                f.write(file_obj.read())
+            f.write(file_obj.read())
         # return the full path to the saved object:
         return destination

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -161,10 +161,7 @@ class ArchController(object):
 
         destination = os.path.join(dir_path, self.binary_name)
         with open(destination, 'wb') as f:
-            try:
-                f.write(file_obj.getvalue())
-            except AttributeError:
-                f.write(file_obj.read())
+            f.write(file_obj.read())
         # return the full path to the saved object:
         return destination
 

--- a/chacra/controllers/binaries/archs.py
+++ b/chacra/controllers/binaries/archs.py
@@ -4,6 +4,7 @@ import pecan
 from pecan import response
 from pecan.secure import secure
 from pecan import expose, abort, request
+from webob.static import FileIter
 from chacra.models import Binary
 from chacra import models, util
 from chacra.controllers import error
@@ -160,8 +161,12 @@ class ArchController(object):
             response.status = 201
 
         destination = os.path.join(dir_path, self.binary_name)
+
         with open(destination, 'wb') as f:
-            f.write(file_obj.read())
+            file_iterable = FileIter(file_obj)
+            for chunk in file_iterable:
+                f.write(chunk)
+
         # return the full path to the saved object:
         return destination
 


### PR DESCRIPTION
Read/write them by chunks using WebOb's built-in helper `FileIter`.

Fixes issue #103 