### PR TITLE
assign a celery worker to the default queue

### DIFF
--- a/deploy/playbooks/roles/common/templates/circus.ini.j2
+++ b/deploy/playbooks/roles/common/templates/circus.ini.j2
@@ -23,7 +23,7 @@ stderr_stream.class = FileStream
 stderr_stream.filename=/var/log/circus/celery-stderr.log
 
 [watcher:celery-worker2]
-cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker2.%h -Q build_repos
+cmd = /opt/chacra/bin/celery -A async worker --loglevel=info -n worker2.%h -Q build_repos,celery
 working_dir=/opt/chacra/src/chacra/chacra
 
 stdout_stream.class = FileStream


### PR DESCRIPTION
celery itself puts messages in the default queue so we need to make sure
there is a worker processesing those.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>