### PR TITLE
restart celery preventing arbitrer collisions

### DIFF
--- a/deploy/playbooks/roles/common/handlers/main.yml
+++ b/deploy/playbooks/roles/common/handlers/main.yml
@@ -14,14 +14,17 @@
 
 - name: "restart celery worker 3"
   command: "{{ app_home }}/bin/circusctl restart celery-worker3"
+  register: celery_worker_3
   when: celery_worker_2.changed
 
 - name: "restart celery worker 4"
   command: "{{ app_home }}/bin/circusctl restart celery-worker4"
+  register: celery_worker_4
   when: celery_worker_3.changed
 
 - name: restart celery beat
   command: "{{ app_home }}/bin/circusctl restart celerybeat"
+  when: celery_worker_4.changed
 
 - name: restart nginx
   sudo: yes

--- a/deploy/playbooks/roles/common/handlers/main.yml
+++ b/deploy/playbooks/roles/common/handlers/main.yml
@@ -2,10 +2,12 @@
 
 - name: restart app
   command: "{{ app_home }}/bin/circusctl restart {{ app_name }}"
+  register: app_restart
 
 - name: restart celery
   command: "{{ app_home }}/bin/circusctl restart celery"
   register: celery_worker
+  when: app_restart.changed
 
 - name: "restart celery worker 2"
   command: "{{ app_home }}/bin/circusctl restart celery-worker2"

--- a/deploy/playbooks/roles/common/tasks/postgresql.yml
+++ b/deploy/playbooks/roles/common/tasks/postgresql.yml
@@ -33,7 +33,7 @@
 
 - name: Make {{ app_name }} user
   postgresql_user:
-    name: "{{ app_name }}" 
+    name: "{{ app_name }}"
     password: "{{ db_password.stdout }}"
     role_attr_flags: SUPERUSER
     login_user: postgres
@@ -62,7 +62,6 @@
   notify:
     - restart app
     - restart celery
-    - restart celery beat
 
 # this needs to be here because it needs the new db password
 - name: create the prod alembic.ini file

--- a/deploy/playbooks/roles/common/tasks/postgresql.yml
+++ b/deploy/playbooks/roles/common/tasks/postgresql.yml
@@ -61,7 +61,6 @@
     dest: "{{ app_home }}/src/{{ app_name }}/prod_db.py"
   notify:
     - restart app
-    - restart celery
 
 # this needs to be here because it needs the new db password
 - name: create the prod alembic.ini file


### PR DESCRIPTION
This is the last thing we are doing on circusctl before we fallback to just using systemd.

