### PR TITLE
Statsd support

### DIFF
--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -6,6 +6,7 @@
     - common
     - repos
     - celery
+    - statsd
   vars:
      app_name: "chacra"
      use_ssl: true
@@ -17,3 +18,6 @@
      branch: "master"
      development_server: false
      fqdn: "chacra.ceph.com"
+
+     # graphite reporting for statsd
+     graphite_host: "shaman.ceph.com"

--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -21,3 +21,6 @@
 
      # graphite reporting for statsd
      graphite_host: "shaman.ceph.com"
+     # this *must* be passed in as an extra-vars option if wanting
+     # to report to the production graphite instance
+     graphite_api_key: false

--- a/deploy/playbooks/deploy_vagrant.yml
+++ b/deploy/playbooks/deploy_vagrant.yml
@@ -6,6 +6,7 @@
     - common
     - repos
     - celery
+    - statsd
   vars:
      app_name: "chacra"
      use_ssl: true

--- a/deploy/playbooks/roles/statsd/defaults/main.yml
+++ b/deploy/playbooks/roles/statsd/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+statsd_debug: 'false'
+statsd_version: v0.8.0
+statsd_port: 8125
+
+graphite_port: 2003
+graphite_host: localhost
+delete_idle_stats: 'false'

--- a/deploy/playbooks/roles/statsd/handlers/main.yml
+++ b/deploy/playbooks/roles/statsd/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: restart statsd
+  sudo: yes
+  service: name=statsd state=restarted enabled=yes
+
+- name: reload systemd
+  sudo: yes
+  sudo: yes
+  command: systemctl daemon-reload

--- a/deploy/playbooks/roles/statsd/handlers/main.yml
+++ b/deploy/playbooks/roles/statsd/handlers/main.yml
@@ -6,5 +6,4 @@
 
 - name: reload systemd
   sudo: yes
-  sudo: yes
   command: systemctl daemon-reload

--- a/deploy/playbooks/roles/statsd/tasks/main.yml
+++ b/deploy/playbooks/roles/statsd/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Install Statsd Dependencies for Debian
+  apt: "name={{ item }} update_cache=yes"
+  sudo: true
+  # nodejs-legacy is required in Xenial so that it provides the `node`
+  # executable
+  with_items:
+    - git
+    - nodejs-legacy
+  when: ansible_pkg_mgr == 'apt'
+
+- name: Create node user
+  sudo: true
+  user: name=node state=present shell=/bin/false system=yes
+
+- name: Install statsd from GitHub
+  git: "repo=https://github.com/etsy/statsd.git dest={{ app_home }}/src/statsd update=no version={{ statsd_version }}"
+
+- name: Get directory permissions
+  stat: path={{ app_home }}/src/statsd
+  register: permissions
+
+- name: Set file permissions
+  sudo: true
+  file: path={{ app_home }}/src/statsd owner=node group=node
+  when: permissions.stat.pw_name != 'node'
+
+- include: systemd.yml
+
+- name: Configure statsd
+  sudo: true
+  template: src=config/localConfig.js.j2 dest={{ app_home }}/src/statsd/localConfig.js owner=node group=node mode=0444
+  notify: restart statsd
+
+- name: Start statsd
+  sudo: true
+  service: name=statsd state=running enabled=yes

--- a/deploy/playbooks/roles/statsd/tasks/systemd.yml
+++ b/deploy/playbooks/roles/statsd/tasks/systemd.yml
@@ -1,0 +1,21 @@
+---
+
+- name: ensure /etc/default/ dir exists
+  sudo: true
+  file: path=/etc/default state=directory
+
+- name: ensure /etc/systemd/system-preset dir exists
+  sudo: true
+  file: path=/etc/systemd/system-preset state=directory
+
+- name: install the systemd unit file for statsd
+  template: src=systemd/statsd.service.j2 dest=/etc/systemd/system/statsd.service
+  sudo: true
+  notify:
+     - reload systemd
+
+- name: install the preset file for statsd
+  template: src=systemd/80-statsd.preset.j2 dest=/etc/systemd/system-preset/80-statsd.preset
+  sudo: true
+  notify:
+     - reload systemd

--- a/deploy/playbooks/roles/statsd/tasks/systemd.yml
+++ b/deploy/playbooks/roles/statsd/tasks/systemd.yml
@@ -7,6 +7,8 @@
 - name: ensure /etc/systemd/system-preset dir exists
   sudo: true
   file: path=/etc/systemd/system-preset state=directory
+  notify:
+     - reload systemd
 
 - name: install the systemd unit file for statsd
   template: src=systemd/statsd.service.j2 dest=/etc/systemd/system/statsd.service

--- a/deploy/playbooks/roles/statsd/templates/config/localConfig.js.j2
+++ b/deploy/playbooks/roles/statsd/templates/config/localConfig.js.j2
@@ -1,0 +1,18 @@
+{
+    port: {{ statsd_port }}
+    ,backends: [
+        {% if graphite_host -%}
+          './backends/graphite',
+        {% endif -%}
+    ]
+{% if statsd_debug == 'true' %}
+    ,debug: {{ statsd_debug }}
+{% endif %}
+{% if graphite_host %}
+    ,graphiteHost: "{{ graphite_host }}"
+    ,graphitePort: {{ graphite_port }}
+{% endif %}
+{% if delete_idle_stats == 'true' %}
+    ,deleteIdleStats: true
+{% endif %}
+}

--- a/deploy/playbooks/roles/statsd/templates/config/localConfig.js.j2
+++ b/deploy/playbooks/roles/statsd/templates/config/localConfig.js.j2
@@ -1,12 +1,18 @@
 {
     port: {{ statsd_port }}
     ,backends: [
-        {% if graphite_host -%}
+        {% if graphite_host %}
           './backends/graphite',
-        {% endif -%}
+        {% endif %}
     ]
 {% if statsd_debug == 'true' %}
     ,debug: {{ statsd_debug }}
+{% endif %}
+{% if graphite_api_key %}
+    graphite
+        {
+            globalPrefix: "{{ graphite_api_key }}"
+        }
 {% endif %}
 {% if graphite_host %}
     ,graphiteHost: "{{ graphite_host }}"

--- a/deploy/playbooks/roles/statsd/templates/systemd/80-statsd.preset.j2
+++ b/deploy/playbooks/roles/statsd/templates/systemd/80-statsd.preset.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+# chacra web service
+
+enable statsd.service

--- a/deploy/playbooks/roles/statsd/templates/systemd/statsd.service.j2
+++ b/deploy/playbooks/roles/statsd/templates/systemd/statsd.service.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+[Unit]
+Description=statsd service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/node stats.js {{ app_home }}/src/statsd/localConfig.js
+User={{ ansible_ssh_user }}
+WorkingDirectory={{ app_home }}/src/statsd
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This gets us statsd support out of the box, including systemd support.

statsd is not packaged so we are force to clone and use the release we need at time of deployment.