### PR TITLE
only reset api creds when passing api_key and api_user

### DIFF
--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -11,7 +11,6 @@
 - name: "ensure a home for {{ app_name }}"
   sudo: yes
   file: path={{ app_home }} owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} state=directory recurse=yes
-  register: app_home_created
 
 - name: Update apt cache
   apt:
@@ -47,8 +46,7 @@
   template:
     src: prod_api_creds.py.j2
     dest: "{{ app_home }}/src/{{ app_name }}/prod_api_creds.py"
-  when: (api_key is defined or api_user is defined) or
-        (app_home_created is defined and app_home_created|changed)
+  when: api_key is defined and api_user is defined
 
 - name: install python requirements in virtualenv
   pip:

--- a/deploy/playbooks/roles/common/templates/prod_api_creds.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_api_creds.py.j2
@@ -1,3 +1,3 @@
 # Basic HTTP Auth credentials
-api_user = "{{ api_user | default('admin') }}"
-api_key = "{{ api_key | default('secret') }}"
+api_user = "{{ api_user }}"
+api_key = "{{ api_key }}"


### PR DESCRIPTION
This used to happen whenever the app_home directory was created as well.
That is causing an issue now because the task that creates the home directory
also sets permissions, and those will always be changed.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>