### PR TITLE
Statsd client

### DIFF
--- a/chacra/metrics.py
+++ b/chacra/metrics.py
@@ -44,6 +44,11 @@ prevail)::
 
     secret.chacra1.custom.path
 
+
+..note:: All these assume a local statsd instance running, so there is no need
+to provide a connection object. If there is ever a need to customize the
+connection, it will need to be provided here.
+
 """
 
 import socket
@@ -62,7 +67,7 @@ def short_hostname(socket):
 def get_prefix(conf=None, host=None):
     host = host or short_hostname()
     conf = conf or pecan.conf
-    secret = getattr(conf, 'graphite_secret', None)
+    secret = getattr(conf, 'graphite_api_key', None)
 
     if secret:
         prefix = "%s.%s" % (secret, host)

--- a/chacra/metrics.py
+++ b/chacra/metrics.py
@@ -1,0 +1,101 @@
+"""
+A wrapper around python-statsd to automatically configure outgoing metrics so
+that it can include, at the highest level::
+
+    secret.hostname.module
+
+Production Graphite instances might require a secret key which should be
+prefixed to outgoing metrics, if not configured, metrics would start off from
+the short hostname::
+
+    hostname.module
+
+Instantiating metrics work similarly to creating a logger instance::
+
+    from metrics import Counter
+
+    counter = Counter(__name__)
+
+    counter += 1
+
+It is allowed to alter the naming appending a suffix::
+
+
+    def my_oddly_named_function():
+        counter = Counter(__name__, suffix='expensive_function')
+        while True:
+            ...
+            counter +=1
+
+This would append 'package.module' with `expensive_function`, but
+just the suffix (the last part of the scheme). For a production host, this
+counter could look like::
+
+    secret.chacra1.chacra.async.expensive_function
+
+
+Although not encouraged, it is possible to fully override with a custom name::
+
+
+    counter = Counter('custom.path')
+
+Which would cause to override the module path (secret key and hostname would
+prevail)::
+
+    secret.chacra1.custom.path
+
+"""
+
+import socket
+import pecan
+import statsd
+
+
+def short_hostname(socket):
+    """
+    Obtains remote hostname of the socket and cuts off the domain part
+    of its FQDN.
+    """
+    return socket.gethostname().split('.', 1)[0]
+
+
+def get_prefix(conf=None, host=None):
+    host = host or short_hostname()
+    conf = conf or pecan.conf
+    secret = getattr(conf, 'graphite_secret', None)
+
+    if secret:
+        prefix = "%s.%s" % (secret, host)
+    else:
+        prefix = "%s" % host
+
+    return prefix
+
+
+def append_suffix(name, suffix):
+    """
+    Helper to append a suffix the end of the name with a custom one. Useful for
+    private functions or signatures that require distinct separation from the
+    module.
+    """
+    name_parts = name.split('.')
+    name_parts.append(suffix)
+    return '.'.join(name_parts)
+
+
+def Counter(name, suffix=None):
+    if suffix:
+        name = append_suffix(name, suffix)
+    return statsd.Counter("%s.%s" % (get_prefix(), name))
+
+
+def Gauge(name, suffix=None):
+    if suffix:
+        name = append_suffix(name, suffix)
+    return statsd.Gauge("%s.%s" % (get_prefix(), name))
+
+
+def Timer(name, suffix=None):
+    if suffix:
+        name = append_suffix(name, suffix)
+    return statsd.Timer("%s.%s" % (get_prefix(), name))

--- a/chacra/tests/conftest.py
+++ b/chacra/tests/conftest.py
@@ -14,6 +14,8 @@ from chacra.tests import util
 import pytest
 
 
+
+
 DBNAME = 'chacratest'
 BIND = 'postgresql+psycopg2://localhost'
 
@@ -40,6 +42,15 @@ def reload_config():
         overwrite=True
     )
     _db.init_model()
+
+
+@pytest.fixture
+def fake():
+    class Fake(object):
+        def __init__(self, *a, **kw):
+            for k, v, in kw.items():
+                setattr(self, k, v)
+    return Fake
 
 
 @pytest.fixture(scope='session')

--- a/chacra/tests/test_metrics.py
+++ b/chacra/tests/test_metrics.py
@@ -18,3 +18,16 @@ class TestAppendSuffix(object):
     def test_gets_suffix_appended_with_dotted_paths(self):
         result = metrics.append_suffix('chacra.async', 'add_rpms')
         assert result == 'chacra.async.add_rpms'
+
+
+class TestGetPrefix(object):
+
+    def test_with_secret(self, fake):
+        conf = fake(graphite_api_key='1234')
+        result = metrics.get_prefix(conf=conf, host='local')
+        assert result == '1234.local'
+
+    def test_no_secret(self, fake):
+        conf = fake()
+        result = metrics.get_prefix(conf=conf, host='local')
+        assert result == 'local'

--- a/chacra/tests/test_metrics.py
+++ b/chacra/tests/test_metrics.py
@@ -1,0 +1,20 @@
+from chacra import metrics
+
+
+class TestHostname(object):
+
+    def test_gets_short_hostname(self, fake):
+        socket = fake(gethostname=lambda: 'chacra.ceph.com')
+        result = metrics.short_hostname(socket=socket)
+        assert result == 'chacra'
+
+
+class TestAppendSuffix(object):
+
+    def test_gets_suffix_appended(self):
+        result = metrics.append_suffix('chacra', 'expensive_function')
+        assert result == 'chacra.expensive_function'
+
+    def test_gets_suffix_appended_with_dotted_paths(self):
+        result = metrics.append_suffix('chacra.async', 'add_rpms')
+        assert result == 'chacra.async.add_rpms'

--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -23,4 +23,4 @@
      graphite_host: "shaman.ceph.com"
      # this *must* be passed in as an extra-vars option if wanting
      # to report to the production graphite instance
-     graphite_api_key: false
+     # graphite_api_key: '1234-asdf-1234'

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -60,6 +60,10 @@ logging = {
     }
 }
 
+# graphite/statsd settings
+graphite_api_key = "{{ graphite_api_key }}"
+
+
 # When True it will set the headers so that Nginx can serve the download
 # instead of Pecan.
 delegate_downloads = True


### PR DESCRIPTION
Relies on the fact that a local statsd service will be running. Requires passing the secret graphite api key every time it deploys.