### PR TITLE
adds a tox.ini for PR testing

### DIFF
--- a/chacra/tests/controllers/test_distros.py
+++ b/chacra/tests/controllers/test_distros.py
@@ -9,7 +9,8 @@ class TestDistroVersionController(object):
         Binary('ceph-1.0.1.deb', p, ref='master', distro='ubuntu', distro_version='trusty', arch='i386')
         session.commit()
         result = session.app.get('/binaries/ceph/master/ubuntu/trusty/')
-        assert result.json == {u'i386': [u'ceph-1.0.1.deb', u'ceph-1.0.0.deb']}
+        assert result.json.keys() == ["i386"]
+        assert set(result.json["i386"]) == set([u'ceph-1.0.0.deb', u'ceph-1.0.1.deb'])
 
 
 class TestDistroController(object):

--- a/chacra/tests/controllers/test_refs.py
+++ b/chacra/tests/controllers/test_refs.py
@@ -29,7 +29,7 @@ class TestRefController(object):
         Binary('ceph-1.0.0.deb', p, ref='master', distro='ubuntu', distro_version='trusty', arch='i386')
         session.commit()
         result = session.app.get('/binaries/ceph/master/')
-        assert result.json.keys() == ['centos', 'ubuntu']
+        assert set(result.json.keys()) == set(['ubuntu', 'centos'])
 
     def test_get_ref_with_distinct_distros(self, session):
         p = Project('ceph')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pecan-notario
 celery[librabbitmq]
 alembic
 ipython
+statsd

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "sqlalchemy",
         "psycopg2",
         "pecan-notario",
+        "statsd",
     ],
     test_suite='chacra',
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps=
+  pytest
+commands=py.test -v {posargs:chacra/tests}
+
+[testenv:flake8]
+deps=flake8
+commands=flake8 --select=F,E9 {posargs:chacra}


### PR DESCRIPTION
I fixed a couple tests as well, we were missing the statsd module from #137 and the other two tests were failing with tox but passing when run with py.test directly. Comparing sets instead of unordered lists fixed that issue.

I've included flake8 tests in the tox.in but did not add them to the ``[tox]`` ``envlist`` because we have quite a few failures and I want to get the ceph-build side of the PR testing working before fixing all those.