### PR TITLE
implements a /health/ endpoint

### DIFF
--- a/chacra/controllers/health.py
+++ b/chacra/controllers/health.py
@@ -1,0 +1,12 @@
+from pecan import expose, abort
+
+from chacra.async import checks
+
+
+class HealthController(object):
+
+    @expose('json')
+    def index(self):
+        if checks.is_healthy():
+            return "Everything OK"
+        abort(500, "Health check failed.")

--- a/chacra/controllers/health.py
+++ b/chacra/controllers/health.py
@@ -5,8 +5,7 @@ from chacra.async import checks
 
 class HealthController(object):
 
-    @expose('json')
+    @expose()
     def index(self):
-        if checks.is_healthy():
-            return "Everything OK"
-        abort(500, "Health check failed.")
+        if not checks.is_healthy():
+            abort(500)

--- a/chacra/controllers/root.py
+++ b/chacra/controllers/root.py
@@ -3,9 +3,11 @@ from chacra.models import Project, Repo
 from chacra.controllers.projects import ProjectsController
 from chacra.controllers.errors import ErrorsController
 from chacra.controllers.search import SearchController
+from chacra.controllers.health import HealthController
 from chacra.controllers.repos.projects import (
     ProjectsController as RepoProjectsController,
 )
+
 
 
 description = """chacra is a binary API that allows querying, posting,
@@ -30,3 +32,4 @@ class RootController(object):
     errors = ErrorsController()
     search = SearchController()
     repos = RepoProjectsController()
+    health = HealthController()

--- a/chacra/tests/controllers/test_health.py
+++ b/chacra/tests/controllers/test_health.py
@@ -6,7 +6,7 @@ class TestHealthController(object):
     def test_passes_health_check(self, session, monkeypatch):
         monkeypatch.setattr(health.checks, "is_healthy", lambda: True)
         result = session.app.get("/health/")
-        assert result.status_int == 200
+        assert result.status_int == 204
 
     def test_fails_health_check(self, session, monkeypatch):
         monkeypatch.setattr(health.checks, "is_healthy", lambda: False)

--- a/chacra/tests/controllers/test_health.py
+++ b/chacra/tests/controllers/test_health.py
@@ -1,0 +1,14 @@
+from chacra.controllers import health
+
+
+class TestHealthController(object):
+
+    def test_passes_health_check(self, session, monkeypatch):
+        monkeypatch.setattr(health.checks, "is_healthy", lambda: True)
+        result = session.app.get("/health/")
+        assert result.status_int == 200
+
+    def test_fails_health_check(self, session, monkeypatch):
+        monkeypatch.setattr(health.checks, "is_healthy", lambda: False)
+        result = session.app.get("/health/", expect_errors=True)
+        assert result.status_int == 500

--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -56,12 +56,14 @@
     name: chacra-celery
     state: stopped
   sudo: yes
+  failed_when: false
 
 - name: stop chacra-celerybeat
   service:
     name: chacra-celerybeat
     state: stopped
   sudo: yes
+  failed_when: false
 
 - name: create the callbacks configuration file
   template:


### PR DESCRIPTION
This will be used by shaman to verify that the chacra node is healthy before giving it out at the ``/api/nodes/next/`` endpoint.