### PR TITLE
ensure all system checks are used

### DIFF
--- a/chacra/async/checks.py
+++ b/chacra/async/checks.py
@@ -70,4 +70,4 @@ def is_healthy():
         except Exception:
             logger.exception('system is unhealthy')
             return False
-        return True
+    return True


### PR DESCRIPTION
We were returning on the first iteration of the system_checks loop in
chacra.async.checks. Derp.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>