### PR TITLE
fixes a couple bugs with the sha1 addition

### DIFF
--- a/chacra/controllers/repos/projects.py
+++ b/chacra/controllers/repos/projects.py
@@ -26,7 +26,7 @@ class ProjectController(object):
         resp = {}
         for ref in self.project.repo_refs:
             resp[ref] = list(set(
-                [r.distro for r in
+                [r.sha1 for r in
                     self.project.built_repos.filter_by(ref=ref).all()]
             ))
         return resp

--- a/chacra/models/projects.py
+++ b/chacra/models/projects.py
@@ -64,7 +64,7 @@ class Project(Base):
         for ref in self.refs:
             json_[ref] = list(
                 set(
-                    [b.distro for b in self.binaries.filter_by(ref=ref).all()]
+                    [b.sha1 for b in self.binaries.filter_by(ref=ref).all()]
                 )
             )
         return json_

--- a/chacra/tests/controllers/repos/test_projects.py
+++ b/chacra/tests/controllers/repos/test_projects.py
@@ -77,13 +77,14 @@ class TestProjectController(object):
             "firefly",
             "ubuntu",
             "trusty",
+            sha1="HEAD",
         )
         repo.path = "some_path"
         session.commit()
         result = session.app.get('/repos/foobar/')
         assert result.status_int == 200
         assert len(result.json) == 1
-        assert result.json == {"firefly": ["ubuntu"]}
+        assert result.json == {"firefly": ["HEAD"]}
 
     def test_project_does_not_exist(self, session):
         result = session.app.get('/repos/foo/', expect_errors=True)
@@ -101,19 +102,21 @@ class TestProjectController(object):
             "firefly",
             "ubuntu",
             "trusty",
+            sha1="HEAD",
         )
         Repo(
             p,
             "hammer",
             "ubuntu",
             "trusty",
+            sha1="HEAD",
         )
         repo.path = "some_path"
         session.commit()
         result = session.app.get('/repos/foobar/')
         assert result.status_int == 200
         assert len(result.json) == 1
-        assert result.json == {"firefly": ["ubuntu"]}
+        assert result.json == {"firefly": ["HEAD"]}
 
     def test_show_multiple_refs_with_built_repos(self, session):
         p = Project('foobar')
@@ -122,12 +125,14 @@ class TestProjectController(object):
             "firefly",
             "ubuntu",
             "trusty",
+            sha1="HEAD",
         )
         repo2 = Repo(
             p,
             "hammer",
             "ubuntu",
             "trusty",
+            sha1="HEAD",
         )
         repo.path = "some_path"
         repo2.path = "some_path"
@@ -135,4 +140,4 @@ class TestProjectController(object):
         result = session.app.get('/repos/foobar/')
         assert result.status_int == 200
         assert len(result.json) == 2
-        assert result.json == {"firefly": ["ubuntu"], "hammer": ["ubuntu"]}
+        assert result.json == {"firefly": ["HEAD"], "hammer": ["HEAD"]}

--- a/chacra/tests/controllers/test_projects.py
+++ b/chacra/tests/controllers/test_projects.py
@@ -58,8 +58,8 @@ class TestProjectController(object):
 
     def test_get_project_refs(self, session):
         p = Project('foobar')
-        Binary('ceph-1.0.0.rpm', p, ref='master', distro='centos', distro_version='el6', arch='i386')
-        Binary('ceph-1.0.0.rpm', p, ref='firefly', distro='centos', distro_version='el6', arch='i386')
+        Binary('ceph-1.0.0.rpm', p, ref='master', sha1="HEAD", distro='centos', distro_version='el6', arch='i386')
+        Binary('ceph-1.0.0.rpm', p, ref='firefly', sha1="HEAD", distro='centos', distro_version='el6', arch='i386')
         session.commit()
         result = session.app.get('/binaries/foobar/')
-        assert result.json == {'firefly': ['centos'], 'master': ['centos']}
+        assert result.json == {'firefly': ['HEAD'], 'master': ['HEAD']}


### PR DESCRIPTION
I had forgotten to update the ProjectController for both repos and binaries so that it would list all refs followed by their sha1s. They were still show refs and then distros.