### PR TITLE
ansible: include hammer ceph-release packages in ceph hammer repos

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -92,6 +92,9 @@ repos = {
             'ceph-deploy': ['master'],
             'radosgw-agent': ['master'],
         },
+        'hammer': {
+            'ceph-release': ['hammer'],
+        },
         'infernalis': {
             'ceph-release': ['infernalis'],
         },


### PR DESCRIPTION
It currently does not add ceph-release to hammer, which causes issues for dated ceph-release packages that point to old locations

See: http://tracker.ceph.com/issues/16916