### PR TITLE
turn off automatic repo creation for ceph

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -84,6 +84,7 @@ quiet_time = 20
 
 repos = {
     'ceph': {
+        'automatic': False,
         'all': {
             # both ceph-deploy and radosgw-agent production builds should go
             # into the "ref" master because otherwise we would be forced to


### PR DESCRIPTION
We want jenkins to start the repo creation after all binaries are uploaded.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>