### PR TITLE
adds a use_self_signed_ssl option

### DIFF
--- a/deploy/playbooks/.gitignore
+++ b/deploy/playbooks/.gitignore
@@ -4,6 +4,7 @@
 
 # these should never make it to version control
 files/ssl/dev
+files/ssl/test
 
 # ignore a hosts file at the top level that was copied from examples/
 /hosts

--- a/deploy/playbooks/examples/deploy_test.yml
+++ b/deploy/playbooks/examples/deploy_test.yml
@@ -34,11 +34,5 @@
      health_ping: true
      health_ping_url: "https://shaman.ceph.com/api/nodes/"
      use_letsencrypt: True
-     #nginx_ssl_cert_path: "/etc/letsencrypt/live/{{ fqdn }}/fullchain.pem"
-     #nginx_ssl_key_path: "/etc/letsencrypt/live/{{ fqdn }}/privkey.pem"
-     # we want to use self-signed certs for now
-     use_self_signed_ssl: True
-     ssl_cert_path: "files/ssl/test/ssl.crt"
-     ssl_key_path: "files/ssl/test/ssl.key"
-     nginx_ssl_cert_path: "/etc/ssl/certs/{{ fqdn }}-bundled.crt"
-     nginx_ssl_key_path: "/etc/ssl/private/{{ fqdn }}.key"
+     nginx_ssl_cert_path: "/etc/letsencrypt/live/{{ fqdn }}/fullchain.pem"
+     nginx_ssl_key_path: "/etc/letsencrypt/live/{{ fqdn }}/privkey.pem"

--- a/deploy/playbooks/examples/deploy_test.yml
+++ b/deploy/playbooks/examples/deploy_test.yml
@@ -34,5 +34,11 @@
      health_ping: true
      health_ping_url: "https://shaman.ceph.com/api/nodes/"
      use_letsencrypt: True
-     nginx_ssl_cert_path: "/etc/letsencrypt/live/{{ fqdn }}/fullchain.pem"
-     nginx_ssl_key_path: "/etc/letsencrypt/live/{{ fqdn }}/privkey.pem"
+     #nginx_ssl_cert_path: "/etc/letsencrypt/live/{{ fqdn }}/fullchain.pem"
+     #nginx_ssl_key_path: "/etc/letsencrypt/live/{{ fqdn }}/privkey.pem"
+     # we want to use self-signed certs for now
+     use_self_signed_ssl: True
+     ssl_cert_path: "files/ssl/test/ssl.crt"
+     ssl_key_path: "files/ssl/test/ssl.key"
+     nginx_ssl_cert_path: "/etc/ssl/certs/{{ fqdn }}-bundled.crt"
+     nginx_ssl_key_path: "/etc/ssl/private/{{ fqdn }}.key"

--- a/deploy/playbooks/roles/common/defaults/main.yml
+++ b/deploy/playbooks/roles/common/defaults/main.yml
@@ -9,3 +9,6 @@ ssl_key_path: "files/ssl/dev/ssl.key"
 # this gives us a way for chacra.ceph.com to avoid
 # using letsencrypt for now as it already has a ssl cert
 use_letsencrypt: False
+# this gives us a way to use self signed certs
+# on non-dev environments
+use_self_signed_ssl: False

--- a/deploy/playbooks/roles/common/tasks/nginx.yml
+++ b/deploy/playbooks/roles/common/tasks/nginx.yml
@@ -38,7 +38,7 @@
     - restart nginx
 
 - include: ssl.yml
-  when: development_server == true
+  when: development_server == true or use_self_signed_ssl
 
 - include: letsencrypt.yml
   when: development_server == false and use_letsencrypt


### PR DESCRIPTION
This allows us to use self signed ssl certs with the
gitbuilder-like test chacra instances.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>