### PR TITLE
show repos at /api/repos/ that do not have a path

### DIFF
--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -22,7 +22,7 @@ class FlavorsController(object):
         self.distro_name = request.context['distro']
         self.ref = request.context['ref']
         self.sha1 = request.context['sha1']
-        self.repos = self.project.built_repos.filter_by(
+        self.repos = self.project.repos.filter_by(
             distro=self.distro_name,
             distro_version=self.distro_version,
             ref=self.ref,
@@ -56,7 +56,7 @@ class RepoController(object):
         if not request.context.get('distro_version'):
             request.context['distro_version'] = self.distro_version
         self.flavor = flavor
-        self.repo = self.project.built_repos.filter_by(
+        self.repo = self.project.repos.filter_by(
             distro=self.distro_name,
             distro_version=self.distro_version,
             ref=self.ref,

--- a/chacra/controllers/repos/distros.py
+++ b/chacra/controllers/repos/distros.py
@@ -21,7 +21,7 @@ class DistroController(object):
             abort(404)
         resp = []
 
-        for repo in self.project.built_repos.filter_by(distro=self.distro_name, ref=self.ref, sha1=self.sha1).all():
+        for repo in self.project.repos.filter_by(distro=self.distro_name, ref=self.ref, sha1=self.sha1).all():
             resp.append(repo.distro_version)
         return list(set(resp))
 

--- a/chacra/controllers/repos/projects.py
+++ b/chacra/controllers/repos/projects.py
@@ -1,6 +1,5 @@
 from pecan import expose, abort, request
 from chacra.models import Project
-from chacra.models.repos import Repo
 from chacra.controllers import error
 from chacra.controllers.repos.refs import RefController
 
@@ -11,8 +10,6 @@ class ProjectController(object):
         self.project_name = project_name
         self.project = Project.query.filter_by(
             name=project_name
-        ).join(Repo).filter(
-            Repo.path != None
         ).first()
         if not self.project:
             abort(404)
@@ -27,7 +24,7 @@ class ProjectController(object):
         for ref in self.project.repo_refs:
             resp[ref] = list(set(
                 [r.sha1 for r in
-                    self.project.built_repos.filter_by(ref=ref).all()]
+                    self.project.repos.filter_by(ref=ref).all()]
             ))
         return resp
 
@@ -41,8 +38,7 @@ class ProjectsController(object):
     @expose('json')
     def index(self):
         resp = {}
-        projects = Project.query.join(Repo).filter(Repo.path != None)
-        for project in projects.all():
+        for project in Project.query.all():
             resp[project.name] = project.repo_refs
         return resp
 

--- a/chacra/controllers/repos/refs.py
+++ b/chacra/controllers/repos/refs.py
@@ -18,12 +18,12 @@ class RefController(object):
         resp = {}
         sha1s = list(set(
             [r.sha1 for r in
-                self.project.built_repos.filter_by(ref=self.ref_name).all()]
+                self.project.repos.filter_by(ref=self.ref_name).all()]
         ))
         for sha1 in sha1s:
             resp[sha1] = list(set(
                 [b.distro for b in
-                    self.project.built_repos.filter_by(ref=self.ref_name, sha1=sha1).all()]
+                    self.project.repos.filter_by(ref=self.ref_name, sha1=sha1).all()]
             ))
         return resp
 

--- a/chacra/controllers/repos/sha1s.py
+++ b/chacra/controllers/repos/sha1s.py
@@ -20,7 +20,7 @@ class SHA1Controller(object):
         for distro in self.project.repo_distros:
             resp[distro] = list(set(
                 [b.distro_version for b in
-                    self.project.built_repos.filter_by(distro=distro, ref=self.ref, sha1=self.sha1).all()]
+                    self.project.repos.filter_by(distro=distro, ref=self.ref, sha1=self.sha1).all()]
             ))
         return resp
 

--- a/chacra/models/projects.py
+++ b/chacra/models/projects.py
@@ -43,19 +43,19 @@ class Project(Base):
 
     @property
     def repo_refs(self):
-        return list(set([r.ref for r in self.built_repos.all()]))
+        return list(set([r.ref for r in self.repos.all()]))
 
     @property
     def repo_sha1s(self):
-        return list(set([r.sha1 for r in self.built_repos.all()]))
+        return list(set([r.sha1 for r in self.repos.all()]))
 
     @property
     def repo_distros(self):
-        return list(set([r.distro for r in self.built_repos.all()]))
+        return list(set([r.distro for r in self.repos.all()]))
 
     @property
     def repo_distro_versions(self):
-        return list(set([r.distro_version for r in self.built_repos.all()]))
+        return list(set([r.distro_version for r in self.repos.all()]))
 
     def __repr__(self):
         try:

--- a/chacra/tests/controllers/repos/test_distros.py
+++ b/chacra/tests/controllers/repos/test_distros.py
@@ -82,7 +82,7 @@ class TestDistroController(object):
                                  expect_errors=True)
         assert result.status_int == 404
 
-    def test_distro_has_no_built_repos(self, session):
+    def test_shows_distro_that_has_no_built_repos(self, session):
         p = Project('foobar')
         Repo(
             p,
@@ -92,9 +92,8 @@ class TestDistroController(object):
             sha1="head",
         )
         session.commit()
-        result = session.app.get('/repos/foobar/firefly/head/ubuntu/',
-                                 expect_errors=True)
-        assert result.status_int == 404
+        result = session.app.get('/repos/foobar/firefly/head/ubuntu/')
+        assert result.json == ["trusty"]
 
     def test_ref_does_not_exist(self, session):
         p = Project('foobar')

--- a/chacra/tests/controllers/repos/test_projects.py
+++ b/chacra/tests/controllers/repos/test_projects.py
@@ -13,7 +13,7 @@ class TestProjectsController(object):
         session.commit()
         result = session.app.get('/repos/')
         assert result.status_int == 200
-        assert result.json == {}
+        assert result.json == {"foobar": []}
 
     def test_single_project_with_built_repos(self, session):
         p = Project('foobar')
@@ -30,7 +30,7 @@ class TestProjectsController(object):
         assert len(result.json) == 1
         assert result.json == {"foobar": ["firefly"]}
 
-    def test_do_not_show_refs_without_built_repos(self, session):
+    def test_does_show_refs_without_built_repos(self, session):
         p = Project('foobar')
         repo = Repo(
             p,
@@ -49,23 +49,21 @@ class TestProjectsController(object):
         result = session.app.get('/repos/')
         assert result.status_int == 200
         assert len(result.json) == 1
-        assert result.json == {"foobar": ["firefly"]}
+        assert sorted(result.json["foobar"]) == sorted(["firefly", "hammer"])
 
-    def test_do_not_list_projects_without_built_repos(self, session):
+    def test_does_list_projects_without_built_repos(self, session):
         p = Project('foobar')
-        repo = Repo(
+        Repo(
             p,
             "firefly",
             "ubuntu",
             "trusty",
         )
-        repo.path = "some_path"
         Project('baz')
         session.commit()
         result = session.app.get('/repos/')
         assert result.status_int == 200
-        assert len(result.json) == 1
-        assert result.json == {"foobar": ["firefly"]}
+        assert len(result.json) == 2
 
 
 class TestProjectController(object):
@@ -92,10 +90,10 @@ class TestProjectController(object):
 
     def test_project_has_no_built_repos(self, session):
         Project('foobar')
-        result = session.app.get('/repos/foobar/', expect_errors=True)
-        assert result.status_int == 404
+        result = session.app.get('/repos/foobar/')
+        assert result.status_int == 200
 
-    def test_do_not_show_refs_without_built_repos(self, session):
+    def test_does_show_refs_without_built_repos(self, session):
         p = Project('foobar')
         repo = Repo(
             p,
@@ -115,8 +113,7 @@ class TestProjectController(object):
         session.commit()
         result = session.app.get('/repos/foobar/')
         assert result.status_int == 200
-        assert len(result.json) == 1
-        assert result.json == {"firefly": ["HEAD"]}
+        assert len(result.json) == 2
 
     def test_show_multiple_refs_with_built_repos(self, session):
         p = Project('foobar')

--- a/chacra/tests/controllers/repos/test_refs.py
+++ b/chacra/tests/controllers/repos/test_refs.py
@@ -43,17 +43,18 @@ class TestRefController(object):
             sha1="head",
         )
         session.commit()
-        result = session.app.get('/repos/foobar/firefly/', expect_errors=True)
-        assert result.status_int == 404
+        result = session.app.get('/repos/foobar/firefly/')
+        assert result.status_int == 200
+        assert len(result.json) == 1
 
-    def test_do_not_show_sha1_without_built_repos(self, session):
+    def test_does_show_sha1_without_built_repos(self, session):
         p = Project('foobar')
         repo = Repo(
             p,
             "firefly",
             "ubuntu",
             "trusty",
-            sha1="head",
+            sha1="sha1",
         )
         Repo(
             p,
@@ -65,9 +66,8 @@ class TestRefController(object):
         repo.path = "some_path"
         session.commit()
         result = session.app.get('/repos/foobar/firefly/')
-        assert result.status_int == 200
-        assert len(result.json) == 1
-        assert result.json == {"head": ["ubuntu"]}
+        assert len(result.json) == 2
+        assert "sha1" in result.json
 
     def test_multiple_sha1_with_built_repos(self, session):
         p = Project('foobar')

--- a/chacra/tests/controllers/repos/test_repos.py
+++ b/chacra/tests/controllers/repos/test_repos.py
@@ -33,6 +33,29 @@ class TestRepoApiController(object):
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
     )
+    def test_repo_exists_no_path(self, session, url):
+        p = Project('foobar')
+        Repo(
+            p,
+            "firefly",
+            "ubuntu",
+            "trusty",
+            sha1="head",
+        )
+        session.commit()
+        result = session.app.get(url)
+        assert result.status_int == 200
+        assert result.json["distro_version"] == "trusty"
+        assert result.json["distro"] == "ubuntu"
+        assert result.json["ref"] == "firefly"
+        assert result.json["sha1"] == "head"
+
+
+    @py.test.mark.parametrize(
+            'url',
+            ['/repos/foobar/firefly/head/ubuntu/trusty/',
+             '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
+    )
     def test_repo_is_not_queued(self, session, url):
         p = Project('foobar')
         repo = Repo(

--- a/chacra/tests/controllers/repos/test_sha1s.py
+++ b/chacra/tests/controllers/repos/test_sha1s.py
@@ -43,31 +43,9 @@ class TestSHA1Controller(object):
             sha1="head",
         )
         session.commit()
-        result = session.app.get('/repos/foobar/firefly/head/', expect_errors=True)
-        assert result.status_int == 404
-
-    def test_do_not_show_distro_without_built_repos(self, session):
-        p = Project('foobar')
-        repo = Repo(
-            p,
-            "firefly",
-            "ubuntu",
-            "trusty",
-            sha1="head",
-        )
-        Repo(
-            p,
-            "firefly",
-            "centos",
-            "7",
-            sha1="head",
-        )
-        repo.path = "some_path"
-        session.commit()
         result = session.app.get('/repos/foobar/firefly/head/')
         assert result.status_int == 200
         assert len(result.json) == 1
-        assert result.json == {"ubuntu": ["trusty"]}
 
     def test_multiple_distros_with_built_repos(self, session):
         p = Project('foobar')


### PR DESCRIPTION
We need this so we can initiate repo creation with chacractl for repos
that have not already been built once.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>