### PR TITLE
Safer json encoding

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -89,7 +89,7 @@ app.conf.update(
 # helpers
 #
 #
-def post_status(state, repo_obj):
+def post_status(state, repo_obj, _callback=None):
     """
     Nicer interface to send a status report on repo creation if configured.
 
@@ -101,6 +101,7 @@ def post_status(state, repo_obj):
     if not getattr(pecan.conf, 'callback_url', False):
         return
     from chacra.async import recurring
+    callback = _callback or recurring.callback.apply_async
     repo_obj_dict = repo_obj.__json__()
     repo_obj_dict['state'] = state
     project_name = repo_obj_dict['project_name']
@@ -109,7 +110,7 @@ def post_status(state, repo_obj):
     # (like datetime objects) so we rely on Pecan to deal with those and encode
     # them for us
     data = pecan.jsonify.encode(repo_obj_dict)
-    recurring.callback.apply_async(
+    callback(
         args=(data, project_name),
     )
 

--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -89,7 +89,7 @@ app.conf.update(
 # helpers
 #
 #
-def post_status(state, json):
+def post_status(state, repo_obj):
     """
     Nicer interface to send a status report on repo creation if configured.
 
@@ -101,31 +101,33 @@ def post_status(state, json):
     if not getattr(pecan.conf, 'callback_url', False):
         return
     from chacra.async import recurring
-    json['state'] = state
-    project_name = json['project_name']
+    repo_obj_dict = repo_obj.__json__()
+    repo_obj_dict['state'] = state
+    project_name = repo_obj_dict['project_name']
+
+    # Some fields from the object may not be JSON serializable by `requests`
+    # (like datetime objects) so we rely on Pecan to deal with those and encode
+    # them for us
+    data = pecan.jsonify.encode(repo_obj_dict)
     recurring.callback.apply_async(
-        args=(json, project_name),
+        args=(data, project_name),
     )
 
 
 def post_requested(repo):
-    json = repo.__json__()
-    post_status('requested', json)
+    post_status('requested', repo)
 
 
 def post_queued(repo):
-    json = repo.__json__()
-    post_status('queued', json)
+    post_status('queued', repo)
 
 
 def post_building(repo):
-    json = repo.__json__()
-    post_status('building', json)
+    post_status('building', repo)
 
 
 def post_ready(repo):
-    json = repo.__json__()
-    post_status('ready', json)
+    post_status('ready', repo)
 
 
 def post_if_healthy():

--- a/chacra/async/recurring.py
+++ b/chacra/async/recurring.py
@@ -88,11 +88,21 @@ def callback(self, data, project_name, url=None):
         url = os.path.join(pecan.conf.callback_url, project_name, '')
     headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
     logger.debug('callback for url: %s', url)
-    user = pecan.conf.callback_user
-    key = pecan.conf.callback_key
+    try:
+        user = pecan.conf.callback_user
+        key = pecan.conf.callback_key
+    except AttributeError:
+        logger.exception('callback authentication information missing')
+        return False
+
     verify_ssl = getattr(pecan.conf, "callback_verify_ssl", True)
+
     if isinstance(data, dict):
-        data = json.dumps(data)
+        try:
+            data = json.dumps(data)
+        except TypeError:
+            logger.exception('could not serialize data')
+            return False
     try:
         requests.post(
             url,

--- a/chacra/async/recurring.py
+++ b/chacra/async/recurring.py
@@ -102,4 +102,8 @@ def callback(self, data, project_name, url=None):
             headers=headers
         )
     except requests.HTTPError as exc:
+        logger.warning('callback failed: %s', str(exc))
         raise self.retry(exc=exc)
+    except Exception:
+        # Celery eats exceptions for breakfast
+        logger.exception('fatal error trying to POST callback')

--- a/chacra/tests/async/test_callbacks.py
+++ b/chacra/tests/async/test_callbacks.py
@@ -1,7 +1,11 @@
+import os
 import pytest
 from pecan import conf
+import requests
 from chacra import async
+from chacra.async import recurring
 from chacra.models import Repo, Project
+from chacra.tests import conftest
 
 
 repo_keys = [
@@ -22,9 +26,59 @@ class TestHelpers(object):
             )
 
     @pytest.mark.parametrize('key', repo_keys)
-    def test_post_request(self, monkeypatch, recorder, key):
+    def test_post_request(self, session, recorder, key):
         conf.callback_url = 'http://localhost/callback'
         f_async = recorder()
         async.post_status('building', self.repo, _callback=f_async)
         result = f_async.recorder_calls[0]['kwargs']['args'][0]
         assert key in result
+        assert '"building"' in result
+
+
+class TestCallbackInvalidConf(object):
+
+    def setup(self):
+        conf.callback_url = 'http://localhost/callback'
+
+    def teardown(self):
+        conftest.reload_config()
+
+    def test_missing_user_and_key(self):
+        assert recurring.callback("{}", 'ceph') is False
+
+    def test_missing_user(self):
+        conf.callback_key = 'key'
+        assert recurring.callback("{}", 'ceph') is False
+
+    def test_missing_key(self):
+        conf.callback_user = 'admin'
+        assert recurring.callback("{}", 'ceph') is False
+
+
+class TestCallback(object):
+
+    def setup(self):
+        conf.callback_url = 'http://localhost/callback'
+        conf.callback_user = 'admin'
+        conf.callback_key = 'key'
+
+    def test_invalid_json(self):
+        # omg this is so invalid
+        assert recurring.callback({'error': Exception}, 'ceph') is False
+
+    def test_requests_correct_project_url(self, monkeypatch, recorder):
+        r = recorder()
+        monkeypatch.setattr(recurring.requests, 'post', r)
+        recurring.callback("{}", 'ceph')
+        result = r.recorder_calls[0]['args'][0]
+        assert result == os.path.join(conf.callback_url, 'ceph', '')
+
+    def test_requests_http_error(self, monkeypatch, fake):
+        # not confident this is testing what really happens. Could not get the
+        # 'retry' behavior from Celery. This just executes the code path to get
+        # to the exception being re-raised by Celery, which might be enough
+        def bad_post(*a, **kw):
+            raise requests.HTTPError('I suck')
+        monkeypatch.setattr(recurring.requests, 'post', bad_post)
+        with pytest.raises(requests.HTTPError):
+            recurring.callback("{}", 'ceph')

--- a/chacra/tests/async/test_callbacks.py
+++ b/chacra/tests/async/test_callbacks.py
@@ -25,6 +25,12 @@ class TestHelpers(object):
             distro_version='7',
             )
 
+    def teardown(self):
+        # callback settings added in test_post_request are "sticky", this
+        # ensures they are reset for other tests that rely on pristine conf
+        # settings
+        conftest.reload_config()
+
     @pytest.mark.parametrize('key', repo_keys)
     def test_post_request(self, session, recorder, key):
         conf.callback_url = 'http://localhost/callback'
@@ -41,6 +47,8 @@ class TestCallbackInvalidConf(object):
         conf.callback_url = 'http://localhost/callback'
 
     def teardown(self):
+        # callback settings added in setup are "sticky", this ensures they are
+        # reset for other tests that rely on pristine conf settings
         conftest.reload_config()
 
     def test_missing_user_and_key(self):
@@ -61,6 +69,11 @@ class TestCallback(object):
         conf.callback_url = 'http://localhost/callback'
         conf.callback_user = 'admin'
         conf.callback_key = 'key'
+
+    def teardown(self):
+        # callback settings added in setup are "sticky", this ensures they are
+        # reset for other tests that rely on pristine conf settings
+        conftest.reload_config()
 
     def test_invalid_json(self):
         # omg this is so invalid

--- a/chacra/tests/async/test_callbacks.py
+++ b/chacra/tests/async/test_callbacks.py
@@ -1,0 +1,30 @@
+import pytest
+from pecan import conf
+from chacra import async
+from chacra.models import Repo, Project
+
+
+repo_keys = [
+        '"needs_update"', '"sha1"', '"is_queued"', '"is_updating"', '"type"',
+        '"modified"', '"signed"', '"state"', '"project_name"', '"distro_version"',
+        '"path"', '"flavor"', '"ref"', '"distro"']
+
+
+class TestHelpers(object):
+
+    def setup(self):
+        self.p = Project('ceph')
+        self.repo = Repo(
+            self.p,
+            ref='firefly',
+            distro='centos',
+            distro_version='7',
+            )
+
+    @pytest.mark.parametrize('key', repo_keys)
+    def test_post_request(self, monkeypatch, recorder, key):
+        conf.callback_url = 'http://localhost/callback'
+        f_async = recorder()
+        async.post_status('building', self.repo, _callback=f_async)
+        result = f_async.recorder_calls[0]['kwargs']['args'][0]
+        assert key in result

--- a/chacra/tests/conftest.py
+++ b/chacra/tests/conftest.py
@@ -49,6 +49,25 @@ def fake():
                 setattr(self, k, v)
     return Fake
 
+@pytest.fixture
+def recorder():
+    class Recorder(object):
+        def __init__(self, *a, **kw):
+            self.recorder_init_call = []
+            self.recorder_calls = []
+            for k, v, in kw.items():
+                setattr(self, k, v)
+            self.recorder_init_call.append(
+                {'args': a, 'kwargs': kw}
+            )
+        def __call__(self, *a, **kw):
+            for k, v, in kw.items():
+                setattr(self, k, v)
+            self.recorder_calls.append(
+                {'args': a, 'kwargs': kw}
+            )
+
+    return Recorder
 
 def pytest_collectstart(collector):
     import os


### PR DESCRIPTION
This fixes the issue where shaman would not get the requests for the various different states of a repo.

Caused by a serialization mishap using `requests` automatic one. The Repo model has a `datetime` field that would cause it to break.

Adds tests (woo hoo tests!) and try/except block in the task to capture failure and report it with logging.