### PR TITLE
remove the Accept header in the recurring.callback task

### DIFF
--- a/chacra/async/recurring.py
+++ b/chacra/async/recurring.py
@@ -86,7 +86,7 @@ def callback(self, data, project_name, url=None):
         if not getattr(pecan.conf, "callback_url", False):
             return
         url = os.path.join(pecan.conf.callback_url, project_name, '')
-    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+    headers = {'Content-type': 'application/json'}
     logger.debug('callback for url: %s', url)
     try:
         user = pecan.conf.callback_user


### PR DESCRIPTION
When this was in place we'd recieve a 406 back from shaman as those
endpoints return json, not plain text.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>