### PR TITLE
pin psycopg2==2.6.1 and sqlalchemy==1.0.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-psycopg2
+psycopg2==2.6.1
 gunicorn
 pecan
-sqlalchemy
+sqlalchemy==1.0.13
 pecan-notario
 celery[librabbitmq]
 alembic

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     license = "MIT",
     install_requires=[
         "pecan",
-        "sqlalchemy",
-        "psycopg2",
+        "sqlalchemy==1.0.13",
+        "psycopg2==2.6.1",
         "pecan-notario",
         "python-statsd",
         "requests",


### PR DESCRIPTION
This is to avoid an error we're seeing very often in the logs:

OperationalError: (psycopg2.OperationalError) SSL connection has been
closed unexpectedly

We do not see this error on chacra.ceph.com which has these versions,
but we do see it on 1.chacra.ceph.com which had 2.6.2 for psycopg2.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>