### PR TITLE
async: if the error is not ENOENT raise, don't raise by default

### DIFF
--- a/chacra/async/recurring.py
+++ b/chacra/async/recurring.py
@@ -89,7 +89,8 @@ def purge_repos(_now=None):
             # no such file, ignore
             if err.errno == errno.ENOENT:
                 pass
-            raise
+            else:
+                raise
         post_deleted(r)
         r.delete()
         models.commit()


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>