### PR TITLE
put chacra nodes in maintenance mode

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -138,4 +138,7 @@ distributions = {
     },
 }
 
+# if this file exists the check at /health/ will fail
+fail_check_trigger_path = "/tmp/fail_check"
+
 # production database configurations are imported from prod_db.py


### PR DESCRIPTION
This adds a health check that looks at the filesystem for a config defined file. If that file exists the health check will fail. This allows us to take a chacra node out of the shaman rotation without stopping services.