### PR TITLE
adds the hostname and short_hostname config options

### DIFF
--- a/chacra/async/__init__.py
+++ b/chacra/async/__init__.py
@@ -166,7 +166,7 @@ def post_if_healthy():
         logger.error("System is not healthy and will not send health ping.")
         return
 
-    hostname = socket.gethostname()
+    hostname = getattr(pecan.conf, 'hostname', socket.gethostname())
     url = os.path.join(health_ping_url, hostname, '')
     logger.info("Posting health ping to: %s", url)
     recurring.callback.apply_async(

--- a/chacra/metrics.py
+++ b/chacra/metrics.py
@@ -58,11 +58,17 @@ import statsd
 
 def short_hostname(_socket=None):
     """
-    Obtains remote hostname of the socket and cuts off the domain part
+    Returns the config option ``short_hostname`` if found.
+
+    If ``short_hostname`` is not defined, it obtains the
+    remote hostname of the socket and cuts off the domain part
     of its FQDN.
     """
-    _socket = _socket or socket
-    return _socket.gethostname().split('.', 1)[0]
+    short_hostname = getattr(pecan.conf, 'short_hostname', None)
+    if not short_hostname:
+        _socket = _socket or socket
+        return _socket.gethostname().split('.', 1)[0]
+    return short_hostname
 
 
 def get_prefix(conf=None, host=None):

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -64,6 +64,8 @@ logging = {
 
 # graphite/statsd settings
 graphite_api_key = "{{ graphite_api_key }}"
+# this value will be used when sending metrics to graphite
+short_hostname = "{{ short_hostname }}"
 
 # When True it will set the headers so that Nginx can serve the download
 # instead of Pecan.

--- a/deploy/playbooks/roles/common/templates/prod_callbacks.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_callbacks.py.j2
@@ -9,3 +9,5 @@ callback_verify_ssl = {{ callback_verify_ssl|default(True) }}
 health_ping = {{ health_ping|default(False) }}
 # note this url will get the hostname appended
 health_ping_url = "{{ health_ping_url|default('') }}"
+# this value will be used when registering the node with shaman
+hostname = "{{ fqdn }}"


### PR DESCRIPTION
We want the``hostname`` config option so we can always be sure we are registering to shaman with the same hostname. There was an issue that required us to temporarily change the hostname on a chacra node and it incorrectly registered itself with shaman before that hostname was corrected.

We want the ``short_hostname`` config option so we can send a nice label to graphite for metrics reporting. Before this change the node ``2.chacra.ceph.com`` was using the label `2` when sending metrics to graphite, which is not very helpful in identifying where the metric originated.