### PR TITLE
more efficient metrics

### DIFF
--- a/chacra/async/debian.py
+++ b/chacra/async/debian.py
@@ -18,7 +18,7 @@ def create_deb_repo(repo_id):
     # TODO: Is it possible we can get an ID that doesn't exist anymore?
     repo = models.Repo.get(repo_id)
     timer = Timer(__name__, suffix="create.deb.%s" % repo.metric_name)
-    counter = Counter(__name__, suffix="create.deb.%s.binaries" % repo.metric_name)
+    counter = Counter(__name__, suffix="create.deb.%s" % repo.metric_name)
     timer.start()
     post_building(repo)
     logger.info("processing repository: %s", repo)
@@ -116,7 +116,6 @@ def create_deb_repo(repo_id):
                 distro_versions=combined_versions,
                 fallback_version=repo.distro_version
             )
-            counter += 1
         except KeyError:  # probably a tar.gz or similar file that should not be added directly
             continue
         for command in commands:
@@ -130,4 +129,5 @@ def create_deb_repo(repo_id):
     repo.is_updating = False
     models.commit()
     timer.stop()
+    counter += 1
     post_ready(repo)

--- a/chacra/async/rpm.py
+++ b/chacra/async/rpm.py
@@ -21,7 +21,7 @@ def create_rpm_repo(repo_id):
     repo = models.Repo.get(repo_id)
     post_building(repo)
     timer = Timer(__name__, suffix="create.rpm.%s" % repo.metric_name)
-    counter = Counter(__name__, suffix="create.rpm.%s.binaries" % repo.metric_name)
+    counter = Counter(__name__, suffix="create.rpm.%s" % repo.metric_name)
     timer.start()
     logger.info("processing repository: %s", repo)
     if util.repository_is_disabled(repo.project.name):
@@ -67,7 +67,6 @@ def create_rpm_repo(repo_id):
         arch_directory = util.infer_arch_directory(binary.name)
         destination_dir = os.path.join(paths['absolute'], arch_directory)
         destination = os.path.join(destination_dir, binary.name)
-        counter += 1
         try:
             if not os.path.exists(destination):
                 os.symlink(source, destination)
@@ -81,4 +80,5 @@ def create_rpm_repo(repo_id):
     repo.is_updating = False
     models.commit()
     timer.stop()
+    counter += 1
     post_ready(repo)

--- a/chacra/models/repos.py
+++ b/chacra/models/repos.py
@@ -90,9 +90,8 @@ class Repo(Base):
 
     @property
     def metric_name(self):
-        return "repos.%s.%s.%s.%s" % (
+        return "repos.%s.%s.%s" % (
             self.project.name,
-            self.ref,
             self.distro,
             self.distro_version,
         )

--- a/chacra/tests/models/test_repos.py
+++ b/chacra/tests/models/test_repos.py
@@ -105,3 +105,21 @@ class TestRepoArch(object):
         session.commit()
         repo = Repo.get(1)
         assert sorted(repo.archs) == sorted(['aarch64', 'x86_64'])
+
+
+class TestRepoMetricNames(object):
+
+    def setup(self):
+        self.p = Project('ceph')
+
+    def test_full_metric_name(self, session):
+        Repo(
+            self.p,
+            ref="master",
+            distro='ubuntu',
+            distro_version='trusty',
+            arch='aarch64',
+        )
+        session.commit()
+        result = Repo.get(1).metric_name
+        assert result == "repos.ceph.ubuntu.trusty"


### PR DESCRIPTION
No need to report back on every ref because there aren't significant differences between master and say, jewel. We want metrics as granular as distro version.

Counters will also not count every binary but every repo. Counting binaries is not too useful because projects tend to have the same amount of binaries.

Repos processed is much more interesting.