### PR TITLE
ansible: configure the statsd logger to get accurate information on reporting

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -37,6 +37,7 @@ logging = {
         'root': {'level': 'INFO', 'handlers': ['console']},
         'chacra': {'level': 'DEBUG', 'handlers': ['console']},
         'pecan': {'level': 'WARNING', 'handlers': ['console']},
+        'statsd': {'level': 'INFO', 'handlers': ['console']},
         'pecan.commands.serve': {'level': 'DEBUG', 'handlers': ['console']},
         'py.warnings': {'handlers': ['console']},
         '__force_dict__': True


### PR DESCRIPTION
We are getting unreasonable high numbers in graphite and we can't really tell _why_ timers are at that level. Timers for repo creation should be reporting a total amount of less than 3600 seconds (1 hour) but they are reporting _millions of seconds_.
