### PR TITLE
ansible: import hostname from prod_callbacks.py into prod.py

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -4,7 +4,7 @@ from chacra import models
 from chacra import hooks
 from prod_db import sqlalchemy
 from prod_api_creds import api_key, api_user
-from prod_callbacks import callback_url, callback_user, callback_key, health_ping, health_ping_url, callback_verify_ssl
+from prod_callbacks import callback_url, callback_user, callback_key, health_ping, health_ping_url, callback_verify_ssl, hostname
 
 
 # Server Specific Configurations


### PR DESCRIPTION
Without this async.post_if_healthy will register to shaman using
whatever the system hostname is, which could be incorrect.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>