### PR TITLE
When making a deb ceph repo filter binaries by ref and sha1

### DIFF
--- a/chacra/async/debian.py
+++ b/chacra/async/debian.py
@@ -55,7 +55,8 @@ def create_deb_repo(repo_id):
             repo.distro,
             None,
             distro_versions=['generic', 'universal', 'any'],
-            ref=repo.ref):
+            ref=repo.ref,
+            sha1=repo.sha1):
         extra_binaries.append(binary)
 
     for project_name, project_refs in conf_extra_repos.items():
@@ -95,7 +96,8 @@ def create_deb_repo(repo_id):
             repo.project.name,
             None,
             distro_version,
-            ref=repo.ref
+            ref=repo.ref,
+            sha1=repo.sha1
         )
 
     # try to create the absolute path to the repository if it doesn't exist

--- a/chacra/tests/test_util.py
+++ b/chacra/tests/test_util.py
@@ -293,6 +293,36 @@ class TestGetBinaries(object):
             ref='firefly')
         assert len(result) == 2
 
+    def test_filter_binaries_by_sha1(self, session):
+        models.Binary(
+            'ceph-1.0.deb',
+            self.p,
+            ref='firefly',
+            distro='ubuntu',
+            distro_version='precise',
+            arch='all',
+            sha1="sha1",
+            )
+        models.Binary(
+            'ceph-1.0.deb',
+            self.p,
+            ref='firefly',
+            distro='ubuntu',
+            distro_version='trusty',
+            arch='all',
+            sha1="head",
+            )
+
+        models.commit()
+        result = util.get_extra_binaries(
+            'ceph',
+            'ubuntu',
+            'trusty',
+            distro_versions=['precise', 'trusty'],
+            ref='firefly',
+            sha1="sha1")
+        assert len(result) == 1
+
 
 class TestRepreproCommand(object):
 

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -150,7 +150,7 @@ def get_extra_repos(project, ref=None, repo_config=None):
     return distinct_ref
 
 
-def get_extra_binaries(project_name, distro, distro_version, distro_versions=None, ref=None):
+def get_extra_binaries(project_name, distro, distro_version, distro_versions=None, ref=None, sha1=None):
     """
     Try to match a given repository with the distinctive  project/ref/distro
     information and return a list of associated binaries
@@ -173,15 +173,15 @@ def get_extra_binaries(project_name, distro, distro_version, distro_versions=Non
     if distro is not None:
         repo_query = repo_query.filter_by(distro=distro)
 
-    if ref is None:
-        # means that we should just get everything that matches our original
-        # query as a list
-        for r in repo_query.all():
-            binaries += [b for b in r.binaries]
-    else:
-        # further filter by using ref but looking for all matching repos
-        for r in repo_query.filter_by(ref=ref).all():
-            binaries += [b for b in r.binaries]
+    if ref is not None:
+        repo_query = repo_query.filter_by(ref=ref)
+
+    if sha1 is not None:
+        repo_query = repo_query.filter_by(sha1=sha1)
+
+    for r in repo_query.all():
+        binaries += [b for b in r.binaries]
+
     logger.info('%d matched binaries found', len(binaries))
     return binaries
 


### PR DESCRIPTION
This will allow us to make combined repos for older versions of ceph that are specific to a ref and sha1. Currently if we try to build an older version of jewel like 10.2.0 it's binaries get thrown out by reprepro because it finds the 10.2.3 version and ignores any older versions.