### PR TITLE
repos: adds a endpoint to retrieve a deb or rpm repo file

### DIFF
--- a/chacra/models/repos.py
+++ b/chacra/models/repos.py
@@ -1,4 +1,7 @@
 import datetime
+import os
+import socket
+from pecan import conf
 from sqlalchemy import Column, Integer, String, ForeignKey, Boolean, DateTime
 from sqlalchemy.orm import relationship, backref, deferred
 from sqlalchemy.event import listen
@@ -80,6 +83,12 @@ class Repo(Base):
             self.distro_version,
             self.flavor,
         )
+
+    @property
+    def base_url(self):
+        hostname = getattr(conf, 'hostname', socket.gethostname())
+        host_url = 'https://%s/' % hostname
+        return os.path.join(host_url, 'r', self.uri, '')
 
     @property
     def is_generic(self):

--- a/chacra/templates/repo.mako
+++ b/chacra/templates/repo.mako
@@ -1,0 +1,24 @@
+% if type == "deb":
+deb ${base_url} ${distro_version} main
+% elif type == "rpm":
+[${project_name}]
+name=${project_name} packages for \$basearch
+baseurl=${base_url}\$basearch
+enabled=1
+gpgcheck=0
+type=rpm-md
+
+[${project_name}-noarch]
+name=${project_name} noarch packages
+baseurl=${base_url}noarch
+enabled=1
+gpgcheck=0
+type=rpm-md
+
+[${project_name}-source]
+name=${project_name} source packages
+baseurl=${base_url}SRPMS
+enabled=1
+gpgcheck=0
+type=rpm-md
+% endif

--- a/chacra/tests/config.py
+++ b/chacra/tests/config.py
@@ -15,6 +15,7 @@ app = {
     'static_root': '%(confdir)s/public',
 #    'default_renderer': 'json',
     'guess_content_type_from_ext': False,
+    'template_path': '%(confdir)s/../templates',
     'hooks': [
         TransactionHook(
             models.start,

--- a/chacra/tests/controllers/repos/test_repos.py
+++ b/chacra/tests/controllers/repos/test_repos.py
@@ -27,6 +27,46 @@ class TestRepoApiController(object):
 
     @py.test.mark.parametrize(
             'url',
+            ['/repos/foobar/firefly/head/ubuntu/trusty/repo/',
+             '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/repo/']
+    )
+    def test_repo_endpoint_deb(self, session, url):
+        p = Project('foobar')
+        Binary(
+            'ceph-1.0.deb',
+            p,
+            distro='ubuntu',
+            distro_version='trusty',
+            arch='x86_64',
+            sha1="head",
+            ref="firefly",
+        )
+        session.commit()
+        result = session.app.get(url)
+        assert "deb" in result.body
+
+    @py.test.mark.parametrize(
+            'url',
+            ['/repos/foobar/firefly/head/centos/7/repo/',
+             '/repos/foobar/firefly/head/centos/7/flavors/default/repo/']
+    )
+    def test_repo_endpoint_rpm(self, session, url):
+        p = Project('foobar')
+        Binary(
+            'ceph-1.0.rpm',
+            p,
+            distro='centos',
+            distro_version='7',
+            arch='x86_64',
+            sha1="head",
+            ref="firefly",
+        )
+        session.commit()
+        result = session.app.get(url)
+        assert "[foobar]" in result.body
+
+    @py.test.mark.parametrize(
+            'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
     )

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -18,6 +18,7 @@ app = {
     'root': 'chacra.controllers.root.RootController',
     'modules': ['chacra'],
     'guess_content_type_from_ext': False,
+    'template_path': '%(confdir)s/chacra/templates',
     'hooks': [
         TransactionHook(
             models.start,


### PR DESCRIPTION
This endpoint can be used by clients to get the contents of
a rpm repo or deb list file for a specific repo, allowing for
clients to easily consume the repos built by chacra.

The endpoint exists at two places:

repo/$project/$ref/$sha1/$distro/$distro_version/repo/

repo/$project/$ref/$sha1/$distro/$distro_version/flavors/$flavor/repo/

Signed-off-by: Andrew Schoen <aschoen@redhat.com>