### PR TITLE
set content type to text/plain for the repo file endpoint

### DIFF
--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -133,7 +133,7 @@ class RepoController(object):
         self.repo_obj.extra = request.json
         return self.repo_obj
 
-    @expose('mako:repo.mako')
+    @expose('mako:repo.mako', content_type="text/plain")
     def repo(self):
         return dict(
             project_name=self.project.name,


### PR DESCRIPTION
This had been defaulted to text/html which made the file
not contain newlines when viewed in a browser.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>