### PR TITLE
configurable repositories to keep

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -86,6 +86,11 @@ polling_cycle = 120
 purge_repos = {{ purge_repos }}
 
 purge_rotation = {
+    'kernel': {
+        'testing': {
+            'keep_minimum': 10
+        }
+    },
     'ceph': {
         'hammer': {
             'days': 30,

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -84,6 +84,29 @@ polling_cycle = 120
 
 {% if purge_repos is defined %}
 purge_repos = {{ purge_repos }}
+
+purge_rotation = {
+    'ceph': {
+        'hammer': {
+            'days': 30,
+            'keep_minimum': 5
+        },
+        'infernalis': {
+            'days': 30,
+            'keep_minimum': 5
+        },
+        'jewel': {
+            'days': 14,
+            'keep_minimum': 10
+        },
+        'kraken': {
+            'days': 14,
+            'keep_minimum': 10
+        }
+    },
+    '__force_dict__': True,
+}
+
 {% endif %}
 
 # Once a "create repo" task is called, how many seconds (if any) to wait before actually


### PR DESCRIPTION
Allows granular configuration (in days) to keep repositories around per project/ref, falling back to the default of 14 days.

It also allows to set a minimum of repositories to keep regardless of the days configured.