### PR TITLE
ansible: purge settings for kernel branches

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -89,6 +89,15 @@ purge_rotation = {
     'kernel': {
         'testing': {
             'keep_minimum': 10
+        },
+        'master': {
+            'keep_minimum': 5
+        },
+        'for-linus': {
+            'keep_minimum': 5
+        },
+        'nightly_pre-single-major': {
+            'keep_minimum': 1
         }
     },
     'ceph': {


### PR DESCRIPTION
master and for-linus are also special, so keep some history around.
nightly_pre-single-major is a built-once branch used for regression
testing and should never expire.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>