### PR TITLE
ansible: include newer ceph-releases for ceph

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -160,6 +160,12 @@ repos = {
         'jewel': {
             'ceph-release': ['jewel'],
         },
+        'kraken': {
+            'ceph-release': ['kraken'],
+        },
+        'luminous': {
+            'ceph-release': ['luminous'],
+        },
         # when more 'testing' refs are built, we need to add them here as well
         'testing': {
             'ceph': ['jewel-rc'],


### PR DESCRIPTION
This configuration change enables the repository creation to include the ceph-release binary when it is available.

Since the ceph-release binary is created separately we must include it when there is a new version of Ceph.  

It is cumbersome to keep updating the configuration in this way, maybe some other solution should be considered