### PR TITLE
ansible: reload nginx after renewing cert

### DIFF
--- a/deploy/playbooks/roles/common/tasks/letsencrypt.yml
+++ b/deploy/playbooks/roles/common/tasks/letsencrypt.yml
@@ -33,8 +33,9 @@
   cron:
     name: "renew letsencrypt cert"
     minute: "0"
-    hour: "6,18"
-    job: "letsencrypt renew --email {{ ssl_support_email }} --agree-tos"
+    hour: "0"
+    day: "1,15"
+    job: "letsencrypt renew --email {{ ssl_support_email }} --agree-tos; service nginx reload"
   sudo: yes
 
 - name: unlink tmp nginx config


### PR DESCRIPTION
The nginx service must be reloaded when the renewed certificate is put in
place.

Additionally, letsencrypt will only renew the certificate if it's due to
expire in <= 30 days.  Attempting to renew roughly every 15 days is
plenty.

Signed-off-by: David Galloway <dgallowa@redhat.com>