### PR TITLE
ansible: Only reload nginx on clean `letsencrypt` exit RC

### DIFF
--- a/deploy/playbooks/roles/common/tasks/letsencrypt.yml
+++ b/deploy/playbooks/roles/common/tasks/letsencrypt.yml
@@ -35,7 +35,7 @@
     minute: "0"
     hour: "0"
     day: "1,15"
-    job: "letsencrypt renew --email {{ ssl_support_email }} --agree-tos; service nginx reload"
+    job: "letsencrypt renew --email {{ ssl_support_email }} --agree-tos && service nginx reload"
   sudo: yes
 
 - name: unlink tmp nginx config


### PR DESCRIPTION
nginx will still get reloaded if the certificate isn't due for renewal
yet but this will least prevent nginx from reloading if `letsencrypt`
fails for any reason.

Signed-off-by: David Galloway <dgallowa@redhat.com>