### PR TITLE
set Origin to "ceph.com" in Debian repo metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -431,7 +431,7 @@ by using the following configuration::
             "DebIndices": "Packages Release . .gz .bz2",
             "DscIndices": "Sources Release .gz .bz2",
             "Contents": ".gz .bz2",
-            "Origin": "RedHat",
+            "Origin": "ceph.com",
             "Description": "",
             "Architectures": "amd64 armhf i386 source",
             "Suite": "stable",

--- a/chacra/tests/config.py
+++ b/chacra/tests/config.py
@@ -90,7 +90,7 @@ distributions = {
         "DebIndices": "Packages Release . .gz .bz2",
         "DscIndices": "Sources Release .gz .bz2",
         "Contents": ".gz .bz2",
-        "Origin": "RedHat",
+        "Origin": "ceph.com",
         "Description": "",
         "Architectures": "amd64 armhf i386 source",
         "Suite": "stable",

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -186,7 +186,7 @@ distributions = {
         "DebIndices": "Packages Release . .gz .bz2",
         "DscIndices": "Sources Release .gz .bz2",
         "Contents": ".gz .bz2",
-        "Origin": "RedHat",
+        "Origin": "ceph.com",
         "Description": "",
         "Architectures": "amd64 arm64 armhf i386 source",
         "Suite": "stable",


### PR DESCRIPTION
These packages are not strictly "Red Hat" packages. They are published with the resources and governance of the upstream ceph.com project.

Alter the "Origin" field in the Debian repo metadata to reflect this.