### PR TITLE
tests: remove host from test database connection

### DIFF
--- a/chacra/tests/conftest.py
+++ b/chacra/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 
 
 DBNAME = 'chacratest'
-BIND = 'postgresql+psycopg2://localhost'
+BIND = 'postgresql+psycopg2://'
 
 
 def config_file():


### PR DESCRIPTION
This will allow local connections from both postgresql 9.3 and 9.5 to
connect successfully. With version 9.5 if you specify a host it will
want to verify that password, but during testing we don't want that to
occur.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>