### PR TITLE
Making some updates to letsencrypt cert maintenance

### DIFF
--- a/deploy/playbooks/examples/deploy_prod.yml
+++ b/deploy/playbooks/examples/deploy_prod.yml
@@ -19,8 +19,7 @@
      repos_root: "/opt/repos"
      branch: "master"
      development_server: false
-     # the current prod ssl setup doesn't use letsencrypt
-     use_letsencrypt: false
+     use_letsencrypt: true
      fqdn: "chacra.ceph.com"
 
      # graphite reporting for statsd
@@ -36,5 +35,5 @@
      callback_user: ""
      callback_key: ""
 
-     nginx_ssl_cert_path: "/etc/ssl/certs/{{ fqdn }}-bundled.crt"
-     nginx_ssl_key_path: "/etc/ssl/private/{{ fqdn }}.key"
+     nginx_ssl_cert_path: "/etc/letsencrypt/live/{{ fqdn }}/fullchain.pem"
+     nginx_ssl_key_path: "/etc/letsencrypt/live/{{ fqdn }}/privkey.pem"

--- a/deploy/playbooks/roles/common/defaults/main.yml
+++ b/deploy/playbooks/roles/common/defaults/main.yml
@@ -3,12 +3,9 @@ app_home: /opt/{{ app_name }}
 app_use_ssl: yes
 ssl_support_email: "adeza@redhat.com"
 ssl_webroot_path: "/var/www/{{ fqdn }}"
-letsencrypt_command: "letsencrypt certonly --webroot -w {{ ssl_webroot_path }} -d {{ fqdn }} --email {{ ssl_support_email }} --agree-tos --renew-by-default"
+letsencrypt_command: "certbot certonly --webroot -w {{ ssl_webroot_path }} -d {{ fqdn }} --email {{ ssl_support_email }} --agree-tos --renew-by-default"
 ssl_cert_path: "files/ssl/dev/ssl.crt"
 ssl_key_path: "files/ssl/dev/ssl.key"
-# this gives us a way for chacra.ceph.com to avoid
-# using letsencrypt for now as it already has a ssl cert
-use_letsencrypt: False
 # this gives us a way to use self signed certs
 # on non-dev environments
 use_self_signed_ssl: False

--- a/deploy/playbooks/roles/common/tasks/letsencrypt.yml
+++ b/deploy/playbooks/roles/common/tasks/letsencrypt.yml
@@ -1,45 +1,44 @@
 ---
+# letsencrypt doesn't recommend using the Ubuntu-provided letsencrypt package
+# https://github.com/certbot/certbot/issues/3538
+# They do recommend using certbot from their PPA for Xenial
+# https://certbot.eff.org/#ubuntuxenial-nginx
+
+- name: install software-properties-common
+  apt:
+    name: software-properties-common
+    state: latest
+    update_cache: yes
+  become: true
+
+- name: add certbot PPA
+  apt_repository:
+    repo: "ppa:certbot/certbot"
+  become: true
+
+- name: install certbot
+  apt:
+    name: python-certbot-nginx
+    state: latest
+    update_cache: yes
+  become: true
 
 - name: ensure letsencrypt acme-challenge path
   file:
     path: "{{ ssl_webroot_path }}"
     state: "directory"
     mode: 0755
-  sudo: yes
-
-- name: unlink app nginx config
-  file:
-    path: "/etc/nginx/sites-enabled/{{ app_name }}.conf"
-    state: "absent"
-  sudo: true
-
-- name: create temporary nginx config
-  template:
-    src: "../templates/nginx_tmp_site.conf"
-    dest: "/etc/nginx/sites-enabled/{{ app_name }}.conf"
-  sudo: true
-
-- name: restart nginx
-  sudo: yes
-  service:
-    name: nginx
-    state: restarted
+  become: true
 
 - name: create (or renew) letsencrypt ssl cert
   command: "{{ letsencrypt_command }}"
-  sudo: yes
+  become: true
 
-- name: setup a cron to renew the SSL cert every day
+- name: setup a cron to attempt to renew the SSL cert every 15ish days
   cron:
     name: "renew letsencrypt cert"
     minute: "0"
     hour: "0"
     day: "1,15"
-    job: "letsencrypt renew --email {{ ssl_support_email }} --agree-tos && service nginx reload"
-  sudo: yes
-
-- name: unlink tmp nginx config
-  file:
-    path: "/etc/nginx/sites-enabled/{{ app_name }}.conf"
-    state: "absent"
-  sudo: true
+    job: "certbot renew --renew-hook='service nginx reload'"
+  become: true

--- a/deploy/playbooks/roles/common/vars/main.yml
+++ b/deploy/playbooks/roles/common/vars/main.yml
@@ -21,7 +21,6 @@ system_packages:
 ssl_requirements:
   - openssl
   - libssl-dev
-  - letsencrypt
 
 circus_system_packages:
   - libzmq-dev


### PR DESCRIPTION
  - chacra.ceph.com now uses a letsencrypt cert
  - the && service nginx reload in the cronjob wasn't working
  - letsencrypt recommends the certbot client anyway
  - got rid of the unnecessary .well-known dance in letsencrypt.yml

Signed-off-by: David Galloway <dgallowa@redhat.com>