### PR TITLE
ansible: use systemctl not service, for reloading nginx

### DIFF
--- a/deploy/playbooks/roles/common/tasks/letsencrypt.yml
+++ b/deploy/playbooks/roles/common/tasks/letsencrypt.yml
@@ -40,5 +40,5 @@
     minute: "0"
     hour: "0"
     day: "1,15"
-    job: "certbot renew --renew-hook='service nginx reload'"
+    job: "certbot renew --renew-hook='systemctl reload nginx'"
   become: true


### PR DESCRIPTION
I believe this might have to do with nginx not being reloaded by the certbot in cron, where `service` lives in /usr/sbin/ and might not be available in `$PATH` when running in cron. Regardless, `service` is not correct anymore (even though it works)