### PR TITLE
async use the base requests exception to catch retries

### DIFF
--- a/chacra/async/recurring.py
+++ b/chacra/async/recurring.py
@@ -200,7 +200,7 @@ def callback(self, data, project_name, url=None):
             headers=headers
         )
         response.raise_for_status()
-    except requests.HTTPError as exc:
+    except requests.RequestException as exc:
         logger.warning('callback failed: %s', str(exc))
         raise self.retry(exc=exc)
     except Exception:


### PR DESCRIPTION
Fixes issues where a 'connection' error is raised, also coming from requests. We should just catch the base `requests` exception and retry.

    [2017-09-12 13:34:33,107: ERROR/Worker-1] fatal error trying to POST callback
    Traceback (most recent call last):
      File "/opt/chacra/src/chacra/chacra/async/recurring.py", line 200, in callback
        headers=headers
      File "/opt/chacra/local/lib/python2.7/site-packages/requests/api.py", line 110, in post
        return request('post', url, data=data, json=json, **kwargs)
      File "/opt/chacra/local/lib/python2.7/site-packages/requests/api.py", line 56, in request
        return session.request(method=method, url=url, **kwargs)
      File "/opt/chacra/local/lib/python2.7/site-packages/requests/sessions.py", line 475, in request
        resp = self.send(prep, **send_kwargs)
      File "/opt/chacra/local/lib/python2.7/site-packages/requests/sessions.py", line 596, in send
        r = adapter.send(request, **kwargs)
      File "/opt/chacra/local/lib/python2.7/site-packages/requests/adapters.py", line 487, in send
        raise ConnectionError(e, request=request)
    ConnectionError: HTTPSConnectionPool(host='shaman.ceph.com', port=443): Max retries exceeded with url: /api/repos/ceph/ (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f526cd32e50>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution',))
