### PR TITLE
Error check msg should not be empty

### DIFF
--- a/chacra/async/checks.py
+++ b/chacra/async/checks.py
@@ -17,6 +17,9 @@ class SystemCheckError(Exception):
     def __init__(self, message):
         self.message = message
 
+    def __str__(self):
+        return self.message
+
 
 def celery_has_workers():
     """

--- a/chacra/tests/async/test_checks.py
+++ b/chacra/tests/async/test_checks.py
@@ -25,6 +25,7 @@ df_communicate_full = (
 'Filesystem                   1K-blocks    Used Available Use% Mounted on\n/dev/mapper/vagrant--vg-root  80909064 2205960  74570036   93% /\n',
 '')
 
+
 class TestDiskHasSpace(object):
 
     def test_it_has_plenty(self, fake):
@@ -44,3 +45,11 @@ class TestDiskHasSpace(object):
         with pytest.raises(SystemCheckError) as err:
             checks.disk_has_space(_popen=lambda *a, **kw: popen)
         assert 'almost full. Used: 93%' in err.value.message
+
+
+class TestErrorMessage(object):
+
+    def test_message_is_captured(self):
+        with pytest.raises(SystemCheckError) as err:
+            raise SystemCheckError('an error message')
+        assert 'an error message' == str(err.value)


### PR DESCRIPTION
This will now help get the actual error message out in logs. It wasn't being displayed before.