### PR TITLE
deploy: Remove unattended-upgrades

### DIFF
--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -20,6 +20,12 @@
     state: present
     create: yes
 
+# Automatic updates to chacra dependencies results in chacra being stopped
+- name: Make sure unattended-upgrades is not installed
+  apt:
+    name: unattended-upgrades
+    state: absent
+
 # rabbitmq must be installed after the hostname is set
 - include: rabbitmq.yml
 


### PR DESCRIPTION
erlang-* packages were automatically updated this morning and caused all chacra-*
services to stop and not restart.

Signed-off-by: David Galloway <dgallowa@redhat.com>