### PR TITLE
include rules for ceph-deploy repos

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -200,15 +200,19 @@ repos = {
         },
         'hammer': {
             'ceph-release': ['hammer'],
+            'ceph-deploy': ['1.5'],
         },
         'infernalis': {
             'ceph-release': ['infernalis'],
+            'ceph-deploy': ['1.5'],
         },
         'jewel': {
             'ceph-release': ['jewel'],
+            'ceph-deploy': ['1.5'],
         },
         'kraken': {
             'ceph-release': ['kraken'],
+            'ceph-deploy': ['1.5'],
         },
         'luminous': {
             'ceph-release': ['luminous'],

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -196,7 +196,6 @@ repos = {
         # because otherwise we would be forced to list every "vN.N.N" ref
         # here to avoid getting cruft like "test" builds
         'all': {
-            'ceph-deploy': ['master'],
             'ceph-medic': ['master'],
         },
         'hammer': {
@@ -213,9 +212,11 @@ repos = {
         },
         'luminous': {
             'ceph-release': ['luminous'],
+            'ceph-deploy': ['master'],
         },
         'mimic': {
             'ceph-release': ['mimic'],
+            'ceph-deploy': ['master'],
         },
         # when more 'testing' refs are built, we need to add them here as well
         'testing': {


### PR DESCRIPTION
This updates the rules so that ceph-deploy packages can go to their supported ceph versions

Anything in master should go into Luminous and newer, while older ones should use the 1.5 branch