### PR TITLE
deploy: Revert removal of unattended-upgrades

### DIFF
--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -20,13 +20,6 @@
     state: present
     create: yes
 
-# Automatic updates to chacra dependencies results in chacra being stopped
-- name: Make sure unattended-upgrades is not installed
-  apt:
-    name: unattended-upgrades
-    state: absent
-  become: true
-
 # rabbitmq must be installed after the hostname is set
 - include: rabbitmq.yml
 


### PR DESCRIPTION
The automatic update of erlang that caused rabbitmq-server to stop is a
bug.  https://bugs.launchpad.net/ubuntu/+source/erlang/+bug/1749959

Reverting https://github.com/ceph/chacra/pull/249

Signed-off-by: David Galloway <dgallowa@redhat.com>