### PR TITLE
ansible: purge settings for iscsi kernels

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -105,7 +105,10 @@ purge_rotation = {
             'keep_minimum': 1
         },
         'ceph-iscsi-stable': {
-            'keep_minimum': 5
+            'keep_minimum': 1
+        },
+        'ceph-iscsi-test': {
+            'keep_minimum': 1
         },
     },
     'calamari': {


### PR DESCRIPTION
Keep one of each to avoid confusing users who get pointed to e.g.
https://shaman.ceph.com/repos/kernel/ceph-iscsi-test with multiple
builds.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>