### PR TITLE
deploy: Increase nginx proxy timeout

### DIFF
--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -36,7 +36,7 @@ server {
       proxy_set_header        X-Forwarded-Proto $scheme;
 
       proxy_pass          http://127.0.0.1:8000;
-      proxy_read_timeout  500;
+      proxy_read_timeout  5000;
     }
 
     location /r/  {


### PR DESCRIPTION
ceph-debuginfo was timing out more frequently due to its size

Signed-off-by: David Galloway <dgallowa@redhat.com>