### PR TITLE
deploy: add nautilus configs for ceph-release packages

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -263,6 +263,10 @@ repos = {
             'ceph-release': ['mimic'],
             'ceph-deploy': ['master'],
         },
+        'nautilus': {
+            'ceph-release': ['nautilus'],
+            'ceph-deploy': ['master'],
+        },
         # when more 'testing' refs are built, we need to add them here as well
         'testing': {
             'ceph': ['jewel-rc'],


### PR DESCRIPTION
These are missing for the main chacra instance which prevents us from creating a nautilus repo with ceph-release and ceph-deploy packages