### PR TITLE
templates: remove escaping

### DIFF
--- a/chacra/templates/repo.mako
+++ b/chacra/templates/repo.mako
@@ -2,8 +2,8 @@
 deb [trusted=yes] ${base_url} ${distro_version} main
 % elif type == "rpm":
 [${project_name}]
-name=${project_name} packages for \$basearch
-baseurl=${base_url}\$basearch
+name=${project_name} packages for $basearch
+baseurl=${base_url}$basearch
 enabled=1
 gpgcheck=0
 type=rpm-md


### PR DESCRIPTION
On CentOS7 and earlier versions of yum, the system could use:

    \$basearch

But on CentOS8, dnf (and yum) breaks. This change is backwards
compatible. There is no reason to escape the dollar character.

```
$ sudo yum -v check-update
Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync
DNF version: 4.0.9
cachedir: /var/cache/dnf
repo: downloading from remote: ceph
ceph packages for \x86_64                                                                                                                                                          134  B/s | 162  B     00:01    
Cannot download 'https://1.chacra.ceph.com/r/ceph/wip-rm37865/7fa7fbadc4b023491a23592ed36af7d1cf25c8ac/centos/8/flavors/default/\x86_64': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried.
Error: Failed to synchronize cache for repo 'ceph'

```