### PR TITLE
Revert "util,models/: include .ddeb when building deb repos"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -436,7 +436,6 @@ by using the following configuration::
             "Architectures": "amd64 armhf i386 source",
             "Suite": "stable",
             "Components": "main",
-            "DDebComponents": "main",
         },
         "ceph": {
             "Description": "Ceph distributed file system",

--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -70,7 +70,6 @@ class Binary(Base):
         extension_map = {
             'rpm': 'rpm',
             'deb': 'deb',
-            'ddeb': 'deb',
             'dsc': 'deb',
             'changes': 'deb'
         }

--- a/chacra/tests/test_util.py
+++ b/chacra/tests/test_util.py
@@ -342,19 +342,6 @@ class TestRepreproCommand(object):
         command = util.reprepro_command('/path', binary)
         assert command[-3] == 'includedeb'
 
-    def test_ddeb_binary(self, session, tmpdir):
-        pecan.conf.distributions_root = str(tmpdir)
-        binary = models.Binary(
-            'ceph-dbgsym-1.1.ddeb',
-            self.p,
-            ref='firefly',
-            distro='ubuntu',
-            distro_version='trusty',
-            arch='all',
-            )
-        command = util.reprepro_command('/path', binary)
-        assert command[-3] == 'includeddeb'
-
     def test_deb_dsc(self, session, tmpdir):
         pecan.conf.distributions_root = str(tmpdir)
         binary = models.Binary(

--- a/chacra/util.py
+++ b/chacra/util.py
@@ -289,7 +289,6 @@ def reprepro_command(repository_path, binary, distro_version=None):
     distro_version = distro_version or binary.distro_version
     include_flags = {
         'deb': 'includedeb',
-        'ddeb': 'includeddeb',
         'dsc': 'includedsc',
         'changes': 'include',
     }

--- a/config/dev.py
+++ b/config/dev.py
@@ -97,7 +97,6 @@ distributions = {
         "Architectures": "amd64 armhf i386 source",
         "Suite": "stable",
         "Components": "main",
-        "DDebComponents": "main",
     },
     "ceph": {
         "Description": "Ceph distributed file system",

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -312,7 +312,6 @@ distributions = {
         "Architectures": "amd64 arm64 armhf i386 source",
         "Suite": "stable",
         "Components": "main",
-        "DDebComponents": "main",
     },
     "ceph": {
         "Description": "Ceph distributed file system",


### PR DESCRIPTION
Reverts ceph/chacra#267

I don't think we are ready for this, and there was no agreement if using a forked binary was the right approach. Reverting for now until we get consensus.