### PR TITLE
async/rpm: Create repodata repo root dir for openSUSE

### DIFF
--- a/chacra/tests/async/test_rpm.py
+++ b/chacra/tests/async/test_rpm.py
@@ -1,0 +1,26 @@
+import pytest
+import subprocess
+from chacra.async import rpm
+
+
+class TestRPM(object):
+
+    @pytest.mark.parametrize("distro", ['opensuse', 'openSUSE', 'sle', 'SLE'])
+    def test__createrepo_opensuse(self, monkeypatch, distro):
+        repo_dirs = ['basepath/noarch', 'basepath/x86_64']
+        basepath = 'basepath'
+        def mock_check_call(*args, **kwargs):
+            assert args == (['createrepo', '--no-database', basepath],)
+
+        monkeypatch.setattr(subprocess, 'check_call', mock_check_call)
+        rpm._createrepo(basepath, repo_dirs, distro)
+
+    @pytest.mark.parametrize("distro", ['centos', 'Fedora', 'RHEL'])
+    def test__createrepo_other(self, monkeypatch, distro):
+        repo_dirs = ['basepath/noarch', 'basepath/x86_64']
+        basepath = 'basepath'
+        def mock_check_call(*args, **kwargs):
+            assert args == (['createrepo', '--no-database', repo_dirs.pop(0)],)
+
+        monkeypatch.setattr(subprocess, 'check_call', mock_check_call)
+        rpm._createrepo(basepath, repo_dirs, distro)


### PR DESCRIPTION
On openSUSE, the repository directory structure is different to the
currently used structure. On openSUSE, we expect something like:

noarch/
repodata/
src/
x86_64/

so the repodata/ dir is on the same level than the other dirs.
This is currently not the case so fix this if the distro is set to
"opensuse".

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>