### PR TITLE
controllers/repos: Create correct repo file for openSUSE/SLE

### DIFF
--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -138,6 +138,7 @@ class RepoController(object):
         return dict(
             project_name=self.project.name,
             base_url=self.repo_obj.base_url,
+            distro_name=self.distro_name.lower(),
             distro_version=self.repo_obj.distro_version,
             type=self.repo_obj.type,
         )

--- a/chacra/templates/repo.mako
+++ b/chacra/templates/repo.mako
@@ -1,6 +1,14 @@
 % if type == "deb":
 deb [trusted=yes] ${base_url} ${distro_version} main
 % elif type == "rpm":
+% if distro_name in ["opensuse", "sle"]:
+[${project_name}]
+name=${project_name} packages
+baseurl=${base_url}
+enabled=1
+gpgcheck=0
+type=rpm-md
+% else:
 [${project_name}]
 name=${project_name} packages for $basearch
 baseurl=${base_url}$basearch
@@ -21,4 +29,5 @@ baseurl=${base_url}SRPMS
 enabled=1
 gpgcheck=0
 type=rpm-md
+% endif
 % endif

--- a/chacra/tests/controllers/repos/test_repos.py
+++ b/chacra/tests/controllers/repos/test_repos.py
@@ -65,6 +65,30 @@ class TestRepoApiController(object):
         session.commit()
         result = session.app.get(url)
         assert b_("[foobar]") in result.body
+        assert b_("noarch") in result.body
+        assert b_("SRPMS") in result.body
+
+    @py.test.mark.parametrize(
+        'url',
+        ['/repos/foobar-opensuse/firefly/head/opensuse/15.1/repo/',
+         '/repos/foobar-opensuse/firefly/head/opensuse/15.1/flavors/default/repo/']
+    )
+    def test_repo_endpoint_rpm_opensuse_sle(self, session, url):
+        p = Project('foobar-opensuse')
+        Binary(
+            'ceph-1.0.rpm',
+            p,
+            distro='opensuse',
+            distro_version='15.1',
+            arch='x86_64',
+            sha1="head",
+            ref="firefly",
+        )
+        session.commit()
+        result = session.app.get(url)
+        assert b_('[foobar-opensuse]') in result.body
+        assert b_("noarch") not in result.body
+        assert b_("SRPMS") not in result.body
 
     @py.test.mark.parametrize(
             'url',


### PR DESCRIPTION
On openSUSE/SLE, a repo file needs to be interpretable by zypper and
the format is slightly different to the on for yum/dnf.
So instead of creating multiple entries, just create a single one.

Fixes: https://tracker.ceph.com/issues/44183

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>