### PR TITLE
Move to latest celery.  This requires a few things:

### DIFF
--- a/chacra/asynch/__init__.py
+++ b/chacra/asynch/__init__.py
@@ -46,7 +46,7 @@ def configure_celery_logging():
 
 
 @worker_init.connect
-def bootstrap_pecan(signal, sender):
+def bootstrap_pecan(signal, sender, **kw):
     try:
         config_path = os.environ['PECAN_CONFIG']
     except KeyError:

--- a/chacra/asynch/checks.py
+++ b/chacra/asynch/checks.py
@@ -2,7 +2,7 @@ import logging
 import os
 import subprocess
 
-from celery.task.control import inspect
+from celery.app.control import Inspect
 from errno import errorcode
 from pecan import conf
 from chacra import models
@@ -27,7 +27,7 @@ def celery_has_workers():
     celery worker(s).  An empty/None result will mean that there aren't any
     celery workers in use.
     """
-    stats = inspect().stats()
+    stats = Inspect().stats()
     if not stats:
         raise SystemCheckError('No running Celery worker was found')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ alembic
 ipython
 python-statsd
 requests
+importlib_metadata<=3.6; python_version<'3.8'

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ except ImportError:
     use_setuptools()
     from setuptools import setup, find_packages
 
+
 setup(
     name='chacra',
     version='0.1',
@@ -20,7 +21,16 @@ setup(
         "pecan-notario",
         "python-statsd",
         "requests",
-        "celery<4.0.0",
+        "celery<=6.2.5",
+        # celery imports kombu, which imports importlib_metadata
+        # for py earlier than 3.8 (in 3.8 importlib.metadata is supplied
+        # in py's stdlib).  But there's a deprecated interface that
+        # kombu uses (see https://github.com/celery/kombu/issues/1339).
+        # Constrain the version of the external importlib_metadata
+        # to avoid the compatibility problem.  (kombu will eventually
+        # have to change, as the stdlib version is also removing the
+        # SelectableGroups dict interface.
+        "importlib_metadata<=3.6; python_version<'3.8'",
     ],
     test_suite='chacra',
     zip_safe=False,
@@ -41,5 +51,4 @@ setup(
         [pecan.command]
         populate=chacra.commands.populate:PopulateCommand
         """
-
 )


### PR DESCRIPTION
1) update bootstrap_pecan to accept new required **kw arg
2) replace deprecated celery.task.control.inspect with
   celery.app.control.Inspect
3) work around evolving interface to importlib_metadata in kombu
   by effectively constraining it to 3.6.  It's complicated; see
   setup.py's comment

Signed-off-by: Dan Mick <dmick@redhat.com>