### PR TITLE
Allow testing with sqlite

### DIFF
--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -213,10 +213,16 @@ listen(Binary, 'before_insert', generate_checksum)
 listen(Binary, 'before_update', generate_checksum)
 
 
-# listen for timestamp modifications
-listen(Binary, 'before_insert', update_timestamp)
-listen(Binary, 'before_update', update_timestamp)
+def add_timestamp_listeners():
+    # listen for timestamp modifications
+    listen(Binary, 'before_insert', update_timestamp)
+    listen(Binary, 'before_update', update_timestamp)
 
+def remove_timestamp_listeners():
+    listen(Binary, 'before_insert', update_timestamp)
+    listen(Binary, 'before_update', update_timestamp)
+
+add_timestamp_listeners()
 
 # listen for any changes to mark the repos
 listen(Binary, 'before_insert', update_repo)

--- a/chacra/models/repos.py
+++ b/chacra/models/repos.py
@@ -4,7 +4,7 @@ import socket
 from pecan import conf
 from sqlalchemy import Column, Integer, String, ForeignKey, Boolean, DateTime
 from sqlalchemy.orm import relationship, backref, deferred
-from sqlalchemy.event import listen
+from sqlalchemy.event import listen, remove
 from sqlalchemy.orm.exc import DetachedInstanceError
 from chacra.models import Base, update_timestamp
 from chacra.models.types import JSONType
@@ -117,6 +117,13 @@ class Repo(Base):
     def archs(self):
         return list(set(b.arch for b in self.binaries))
 
-# listen for timestamp modifications
-listen(Repo, 'before_insert', update_timestamp)
-listen(Repo, 'before_update', update_timestamp)
+def add_timestamp_listeners():
+    # listen for timestamp modifications
+    listen(Repo, 'before_insert', update_timestamp)
+    listen(Repo, 'before_update', update_timestamp)
+
+def remove_timestamp_listeners():
+    remove(Repo, 'before_insert', update_timestamp)
+    remove(Repo, 'before_update', update_timestamp)
+
+add_timestamp_listeners()

--- a/chacra/tests/async/test_recurring.py
+++ b/chacra/tests/async/test_recurring.py
@@ -1,9 +1,26 @@
 import datetime
 import os
+import pytest
 from pecan import conf
 from chacra.tests import conftest
 from chacra.asynch import recurring
 from chacra.models import Repo, Project, Binary
+from chacra.models.repos import (
+    add_timestamp_listeners as add_repo_listeners,
+    remove_timestamp_listeners as remove_repo_listeners
+)
+from chacra.models.binaries import (
+    add_timestamp_listeners as add_binary_listeners,
+    remove_timestamp_listeners as remove_binary_listeners
+)
+
+@pytest.fixture
+def no_update_timestamp():
+    remove_repo_listeners()
+    remove_binary_listeners()
+    yield
+    add_repo_listeners()
+    add_binary_listeners()
 
 
 class TestPurgeRepos(object):
@@ -16,12 +33,14 @@ class TestPurgeRepos(object):
             distro='centos',
             distro_version='7',
             )
-        # this is so very very painful to setup because it is just impossible
-        # to patch sqlalchemy event listeners which set the modified attribute
-        # on these objects. Instead we are able to patch datetime, so we mangle
-        # it to assert that purging will work
+
         self.now = datetime.datetime.utcnow()
-        self.old = self.now - datetime.timedelta(weeks=3)
+        # slightly old
+        self.one_minute = self.now - datetime.timedelta(minutes=1)
+        # really old
+        self.three_weeks_ago = self.now - datetime.timedelta(weeks=3)
+
+        self.repo.modified = self.three_weeks_ago
         conf.purge_repos = True
 
     def teardown(self):
@@ -30,46 +49,37 @@ class TestPurgeRepos(object):
         # settings
         conftest.reload_config()
 
-    def test_gets_rid_of_old_repos(self, session, fake, monkeypatch):
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
+    def test_gets_rid_of_old_repos(self, session, no_update_timestamp):
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert Repo.query.all() == []
 
-    def test_does_not_get_rid_of_old_repos_by_ref_configured_in_days(self, session, fake, monkeypatch):
+    def test_does_not_get_rid_of_old_repos_by_ref_configured_in_days(self, session, no_update_timestamp):
         conf.purge_rotation = {'ceph': {'ref': {'firefly': {'days': 70}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_does_not_get_rid_of_old_repos_by_ref_configured_with_offset(self, session, fake, monkeypatch):
+    def test_does_not_get_rid_of_old_repos_by_ref_configured_with_offset(self, session, no_update_timestamp):
         conf.purge_rotation = {'ceph': {'ref': {'firefly': {'keep_minimum': 1}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_does_not_get_rid_of_old_repos_by_flavor_configured_in_days(self, session, fake, monkeypatch):
+    def test_does_not_get_rid_of_old_repos_by_flavor_configured_in_days(self, session, no_update_timestamp):
         conf.purge_rotation = {'ceph': {'flavor': {'default': {'days': 70}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_does_not_get_rid_of_old_repos_by_flavor_configured_with_offset(self, session, fake, monkeypatch):
+    def test_does_not_get_rid_of_old_repos_by_flavor_configured_with_offset(self, session, no_update_timestamp):
         conf.purge_rotation = {'ceph': {'flavor': {'default': {'keep_minimum': 1}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_get_rid_of_new_and_old_repos_by_ref_configured_in_days(self, session, fake, monkeypatch):
+
+    def test_get_rid_of_new_and_old_repos_by_ref_configured_in_days(self, session, no_update_timestamp):
         Repo(
             project=Project('nfs-ganesha'),
             ref='next',
@@ -77,71 +87,65 @@ class TestPurgeRepos(object):
             distro_version='7',
             flavor='ceph_master',
         )
-
+        # cause lifespan for this repo to be 0 days, thus remove it
         conf.purge_rotation = {'nfs-ganesha': {'ref': {'next': {'days': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 0
 
-    def test_get_rid_of_new_and_old_repos_by_ref_configured_with_offset(self, session, fake, monkeypatch):
-        Repo(
+    def test_get_rid_of_old_but_keep_new_by_ref_configured_with_offset(self, session, no_update_timestamp):
+        repo = Repo(
             project=Project('nfs-ganesha'),
             ref='next',
             distro='centos',
             distro_version='7',
             flavor='ceph_master',
         )
+        repo.modified = self.one_minute
 
         conf.purge_rotation = {'nfs-ganesha': {'ref': {'next': {'keep_minimum': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
-        assert len(Repo.query.all()) == 0
-
-    def test_get_rid_of_new_and_old_repos_by_flavor_configured_in_days(self, session, fake, monkeypatch):
-        Repo(
-            project=Project('nfs-ganesha'),
-            ref='next',
-            distro='centos',
-            distro_version='7',
-            flavor='ceph_master',
-        )
-
-        conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'days': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
-        session.commit()
-        recurring.purge_repos(_now=self.now)
-        assert len(Repo.query.all()) == 0
-
-    def test_get_rid_of_new_and_old_repos_by_flavor_configured_with_offset(self, session, fake, monkeypatch):
-        Repo(
-            project=Project('nfs-ganesha'),
-            ref='next',
-            distro='centos',
-            distro_version='7',
-            flavor='ceph_master',
-        )
-
-        conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
-        session.commit()
-        recurring.purge_repos(_now=self.now)
-        assert len(Repo.query.all()) == 0
-
-    def test_does_not_get_rid_of_old_repos_by_flavor_and_ref(self, session, fake, monkeypatch):
-        conf.purge_rotation = {'ceph': {'flavor': {'default': {'keep_minimum': 1}}, 'ref': {'firefly': {'days': 70}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
-        session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_keeps_new_repo_by_flavor_with_days(self, session, fake, monkeypatch):
+    def test_get_rid_of_new_and_old_repos_by_flavor_configured_in_days(self, session, no_update_timestamp):
+        repo = Repo(
+            project=Project('nfs-ganesha'),
+            ref='next',
+            distro='centos',
+            distro_version='7',
+            flavor='ceph_master',
+        )
+        repo.modified = self.one_minute
+
+        # cause lifespan for this repo to be 0 days, thus remove it
+        conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'days': 0}}}, '__force_dict__': True}
+        session.commit()
+        recurring.purge_repos()
+        assert len(Repo.query.all()) == 0
+
+    def test_get_rid_of_old_but_keep_new_repo_by_flavor_configured_with_offset(self, session, no_update_timestamp):
+        repo = Repo(
+            project=Project('nfs-ganesha'),
+            ref='next',
+            distro='centos',
+            distro_version='7',
+            flavor='ceph_master',
+        )
+        repo.modified = self.one_minute
+
+        conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 0}}}, '__force_dict__': True}
+        session.commit()
+        recurring.purge_repos()
+        assert len(Repo.query.all()) == 1
+
+    def test_does_not_get_rid_of_old_repos_by_flavor_and_ref(self, session, no_update_timestamp):
+        conf.purge_rotation = {'ceph': {'flavor': {'default': {'keep_minimum': 1}}, 'ref': {'firefly': {'days': 70}}}, '__force_dict__': True}
+        session.commit()
+        recurring.purge_repos()
+        assert len(Repo.query.all()) == 1
+
+    def test_keeps_new_repo_by_flavor_with_days(self, session, no_update_timestamp):
         Repo(
             project=Project('nfs-ganesha'),
             ref='next',
@@ -151,13 +155,11 @@ class TestPurgeRepos(object):
         )
 
         conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 0, 'days': 70}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_keeps_new_repo_by_flavor_with_offset(self, session, fake, monkeypatch):
+    def test_keeps_new_repo_by_flavor_with_offset(self, session, no_update_timestamp):
         Repo(
             project=Project('nfs-ganesha'),
             ref='next',
@@ -167,14 +169,12 @@ class TestPurgeRepos(object):
         )
 
         conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 1, 'days': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
 
-    def test_keeps_new_repo_by_flavor_with_offset_bad_ref_days(self, session, fake, monkeypatch):
+    def test_keeps_new_repo_by_flavor_with_offset_bad_ref_days(self, session, no_update_timestamp):
         Repo(
             project=Project('nfs-ganesha'),
             ref='next',
@@ -184,13 +184,11 @@ class TestPurgeRepos(object):
         )
 
         conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 1}}, 'ref': {'next': {'days': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_keeps_new_repo_by_ref_with_days_bad_flavor_offset(self, session, fake, monkeypatch):
+    def test_keeps_new_repo_by_ref_with_days_bad_flavor_offset(self, session, no_update_timestamp):
         Repo(
             project=Project('nfs-ganesha'),
             ref='next',
@@ -200,14 +198,12 @@ class TestPurgeRepos(object):
         )
 
         conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 0}}, 'ref': {'next': {'days': 70}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
 
-    def test_get_rid_of_new_repo_with_ref_and_flavor(self, session, fake, monkeypatch):
+    def test_get_rid_of_new_repo_with_ref_and_flavor(self, session, no_update_timestamp):
         Repo(
             project=Project('nfs-ganesha'),
             ref='next',
@@ -217,13 +213,11 @@ class TestPurgeRepos(object):
         )
 
         conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 0}}, 'ref': {'next': {'days': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 0
 
-    def test_get_rid_of_new_repos_without_offset(self, session, fake, monkeypatch):
+    def test_get_rid_of_new_repos_without_offset(self, session, no_update_timestamp):
         Repo(
             project=Project('nfs-ganesha'),
             ref='next',
@@ -233,30 +227,27 @@ class TestPurgeRepos(object):
         )
 
         conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'days': 0}}, 'ref': {'next': {'days': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 0
 
 
-    def test_get_rid_of_new_and_old_repos_without_days(self, session, fake, monkeypatch):
-        Repo(
+    def test_get_rid_of_new_and_old_repos_without_days(self, session, no_update_timestamp):
+        repo = Repo(
             project=Project('nfs-ganesha'),
             ref='next',
             distro='centos',
             distro_version='7',
             flavor='ceph_master',
         )
+        repo.modified = self.three_weeks_ago
 
         conf.purge_rotation = {'nfs-ganesha': {'flavor': {'ceph_master': {'keep_minimum': 0}}, 'ref': {'next': {'keep_minimum': 0}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 0
 
-    def test_gets_rid_of_other_repos(self, session, fake, monkeypatch):
+    def test_gets_rid_of_other_repos(self, session, no_update_timestamp):
         Repo(
             self.p,
             ref='hammer',
@@ -265,36 +256,28 @@ class TestPurgeRepos(object):
         )
 
         conf.purge_rotation = {'ceph': {'ref': {'firefly': {'keep_minimum': 1}}}, '__force_dict__': True}
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert Repo.query.first().ref == 'firefly'
 
-    def test_gets_rid_of_old_repos_paths(self, session, fake, monkeypatch, tmpdir):
+    def test_gets_rid_of_old_repos_paths(self, session, no_update_timestamp, tmpdir):
         repo_path = str(tmpdir)
         package = tmpdir.join('ceph-1.0.rpm')
         package.write("101010101010")
         self.repo.path = str(repo_path)
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert os.path.exists(repo_path) is False
 
-    def test_leaves_newer_repos_behind(self, session, fake, monkeypatch):
+    def test_leaves_newer_repos_behind(self, session, no_update_timestamp):
+        self.repo.modified = self.now
         session.commit()
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
-        session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
-    def test_deletes_related_binaries_as_well(self, session, fake, monkeypatch, tmpdir):
+    def test_deletes_related_binaries_as_well(self, session, no_update_timestamp, tmpdir):
         p = tmpdir.join('binary')
         p.write('contents')
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         Binary(
             'ceph-10.0.0.rpm', self.p, distro='centos',
             distro_version='6',
@@ -304,14 +287,12 @@ class TestPurgeRepos(object):
         )
         session.commit()
         assert len(Binary.query.all()) == 1
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Binary.query.all()) == 0
 
-    def test_ignores_binaries_that_do_not_exist(self, session, fake, monkeypatch, tmpdir):
+    def test_ignores_binaries_that_do_not_exist(self, session, no_update_timestamp, tmpdir):
         p = tmpdir.join('binary')
         p.write_text(u'contents', encoding='utf-8')
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         Binary(
             'ceph-10.0.0.rpm', self.p, distro='centos',
             distro_version='6',
@@ -323,15 +304,13 @@ class TestPurgeRepos(object):
         # remove the binary, to ensure that the purge can continue
         os.remove(str(p))
         assert len(Binary.query.all()) == 1
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Binary.query.all()) == 0
 
-    def test_if_disabled_it_does_not_purge_binaries(self, session, fake, monkeypatch, tmpdir):
+    def test_if_disabled_it_does_not_purge_binaries(self, session, no_update_timestamp, tmpdir):
         conf.purge_repos = False
         p = tmpdir.join('binary')
         p.write('contents')
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         Binary(
             'ceph-10.0.0.rpm', self.p, distro='centos',
             distro_version='6',
@@ -340,15 +319,13 @@ class TestPurgeRepos(object):
             repo=self.repo
         )
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Binary.query.all()) == 1
 
-    def test_does_not_get_rid_of_old_repos(self, session, fake, monkeypatch):
+    def test_does_not_get_rid_of_old_repos(self, session, no_update_timestamp):
         conf.purge_repos = False
-        fake_datetime = fake(utcnow=lambda: self.old, now=self.now)
-        monkeypatch.setattr(datetime, 'datetime', fake_datetime)
         session.commit()
-        recurring.purge_repos(_now=self.now)
+        recurring.purge_repos()
         assert len(Repo.query.all()) == 1
 
 


### PR DESCRIPTION
This includes https://github.com/ceph/chacra/pull/291, but doesn't strictly have to.  It's inconvenient to have to have postgres running on your test machine; sqlite is lots easier to set up.  

Only a few small changes, and almost all the tests pass, but the skipped tests are ugly; not sure of a better way around it.  The problem is the sqlite driver in sqlalchemy does "if isinstance(value-to-print, datetime.datetime)" so monkeypatching datetime.datetime makes that code throw an exception.