### PR TITLE
Add 'raw' repo support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,6 +317,13 @@ The default repository structure URL looks like::
 
     /repos/{project}/{ref}/{sha1}/{distro}/{distro version}/{REPO}
 
+The type of repository (rpm or deb) is usually inferred from the type
+of binaries uploaded; however, 'raw' repos are also supported.  To set
+the repo type, POST to the repo URL and include a data payload that contains
+a JSON structure
+
+    {"type": "raw"}
+
 
 Defining custom repositories
 ----------------------------

--- a/chacra/schemas/__init__.py
+++ b/chacra/schemas/__init__.py
@@ -6,4 +6,5 @@ repo_schema = (
     (optional("distro_version"), types.string),
     (optional("needs_update"), types.boolean),
     (optional("ref"), types.string),
+    (optional("type"), types.string),
 )


### PR DESCRIPTION
Add support for "raw" repos, which are just container folders for binaries that don't need traditional repo construction.