### PR TITLE
Pin gunicorn to < 20.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2==2.8.2
-gunicorn
+gunicorn<20.1.0
 pecan
 sqlalchemy==1.3.0
 pecan-notario


### PR DESCRIPTION
See https://github.com/benoitc/gunicorn/issues/2741.  Basically gunicorn
breaks pecan, and I *think* it's gunicorn's fault at this point.

Signed-off-by: Dan Mick <dmick@redhat.com>