### PR TITLE
deploy: Don't make stopping apache2 fatal

### DIFF
--- a/deploy/playbooks/roles/common/tasks/nginx.yml
+++ b/deploy/playbooks/roles/common/tasks/nginx.yml
@@ -67,7 +67,11 @@
 
 - name: stop/disable apache2
   become: true
-  action: service name=apache2 enabled=true state=stopped
+  service:
+    name: apache2
+    enabled: false
+    state: stopped
+  failed_when: false
   tags: apachestop
 
 - name: ensure nginx is restarted


### PR DESCRIPTION
This task fails if apache2 isn't installed.

Signed-off-by: David Galloway <dgallowa@redhat.com>