### PR TITLE
Fix a number of issues with updating celery, bugs in disk space check

### DIFF
--- a/chacra/asynch/__init__.py
+++ b/chacra/asynch/__init__.py
@@ -63,7 +63,7 @@ def bootstrap_pecan(signal, sender, **kw):
 
 app = Celery(
     'chacra.asynch',
-    broker='amqp://guest@localhost//',
+    broker='pyamqp://guest@localhost//',
     include=['chacra.asynch.rpm', 'chacra.asynch.debian', 'chacra.asynch.recurring']
 )
 

--- a/chacra/asynch/checks.py
+++ b/chacra/asynch/checks.py
@@ -7,6 +7,7 @@ from errno import errorcode
 from pecan import conf
 from chacra import models
 from sqlalchemy.exc import OperationalError
+from chacra.asynch import app
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ def celery_has_workers():
     celery worker(s).  An empty/None result will mean that there aren't any
     celery workers in use.
     """
-    stats = Inspect().stats()
+    stats = app.control.inspect().stats()
     if not stats:
         raise SystemCheckError('No running Celery worker was found')
 

--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -183,10 +183,8 @@ def generate_checksum(mapper, connection, target):
     if not target.path:
         return
     chsum = hashlib.sha512()
-    with open(target.path) as f:
-        for chunk in iter(lambda: f.read(4096), ""):
-            if not isinstance(chunk, bytes):
-                chunk = chunk.encode('utf-8')
+    with open(target.path, 'rb') as f:
+        for chunk in iter(lambda: f.read(4096), b''):
             chsum.update(chunk)
         target.checksum = chsum.hexdigest()
 

--- a/chacra/tests/async/test_checks.py
+++ b/chacra/tests/async/test_checks.py
@@ -18,30 +18,33 @@ class TestIsHealthy(object):
 
 
 df_communicate = (
-'Filesystem                   1K-blocks    Used Available Use% Mounted on\n/dev/mapper/vagrant--vg-root  80909064 2205960  74570036   3% /\n',
+b'Filesystem                   1K-blocks    Used Available Use% Mounted on\n/dev/mapper/vagrant--vg-root  80909064 2205960  74570036   3% /\n',
 '')
 
 df_communicate_full = (
-'Filesystem                   1K-blocks    Used Available Use% Mounted on\n/dev/mapper/vagrant--vg-root  80909064 2205960  74570036   93% /\n',
+b'Filesystem                   1K-blocks    Used Available Use% Mounted on\n/dev/mapper/vagrant--vg-root  80909064 2205960  74570036   93% /\n',
 '')
 
+def fake_wait(timeout=0):
+    return True
 
 class TestDiskHasSpace(object):
 
+
     def test_it_has_plenty(self, fake):
-        popen = fake(returncode=0, communicate=lambda: df_communicate)
+        popen = fake(returncode=0, wait=fake_wait, communicate=lambda: df_communicate)
         result = checks.disk_has_space(_popen=lambda *a, **kw: popen)
         assert result is None
 
     def test_it_has_an_error(self, fake):
-        stderr = fake(read=lambda: "df had an error")
-        popen = fake(returncode=1, stderr=stderr)
+        stderr = fake(read=lambda: b'df had an error')
+        popen = fake(returncode=1, wait=fake_wait, stderr=stderr)
         with pytest.raises(SystemCheckError) as err:
             checks.disk_has_space(_popen=lambda *a, **kw: popen)
-        assert err.value.message == 'failed disk check: df had an error'
+        assert 'df had an error' in err.value.message
 
     def test_it_is_full(self, fake):
-        popen = fake(returncode=0, communicate=lambda: df_communicate_full)
+        popen = fake(returncode=0, wait=fake_wait, communicate=lambda: df_communicate_full)
         with pytest.raises(SystemCheckError) as err:
             checks.disk_has_space(_popen=lambda *a, **kw: popen)
         assert 'almost full. Used: 93%' in err.value.message


### PR DESCRIPTION
1) really fix the checks.py call for celery_has_workers() (not Inspect(), but app.control.inspect())
2) fix up disk_has_space checks: wrong config item name, popen() result not waited for, Py3 stdout/err are binary
3) force use of py-amqp rather than librabbitmq; the latter is apparently deprecated and is causing problems.
4) improve disk_has_space: check both repos_root and binary_root
5) (added late): fix binary checksum calculation for Py3.