### PR TITLE
debian.py: Make sure subprocess is complete before checking returncode

### DIFF
--- a/chacra/asynch/debian.py
+++ b/chacra/asynch/debian.py
@@ -123,9 +123,9 @@ def create_deb_repo(repo_id):
         for command in commands:
             logger.info('running command: %s', ' '.join(command))
             result = subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            stdout, stderr = result.communicate()
             if result.returncode > 0:
                 logger.error('failed to add binary %s', binary.name)
-            stdout, stderr = result.communicate()
             for line in stdout.split('\n'):
                 logger.info(line)
             for line in stderr.split('\n'):


### PR DESCRIPTION
This was always wrong; there was always a race between the subprocess
and the returncode check.  Something about moving to Py3 has
exposed this (perhaps the implementation had a mistaken wait, or
perhaps the new implementation is just faster.)

Anyway, since we're already using communicate(), move it to before the
returncode check, as it will wait for process completion.

Signed-off-by: Dan Mick <dmick@redhat.com>