### PR TITLE
debian: decode() subprocess output

### DIFF
--- a/chacra/asynch/debian.py
+++ b/chacra/asynch/debian.py
@@ -126,6 +126,8 @@ def create_deb_repo(repo_id):
             stdout, stderr = result.communicate()
             if result.returncode > 0:
                 logger.error('failed to add binary %s', binary.name)
+            stdout = stdout.decode()
+            stderr = stderr.decode()
             for line in stdout.split('\n'):
                 logger.info(line)
             for line in stderr.split('\n'):


### PR DESCRIPTION
It's Py3, the pipes are binary and return b''

Signed-off-by: Dan Mick <dmick@redhat.com>