### PR TITLE
deploy: Install zstd for reprepro

### DIFF
--- a/deploy/playbooks/roles/common/vars/main.yml
+++ b/deploy/playbooks/roles/common/vars/main.yml
@@ -18,6 +18,7 @@ system_packages:
 #  - libsemanage-python
   - python
   - liblz4-tool
+  - zstd
 
 ssl_requirements:
   - openssl


### PR DESCRIPTION
https://github.com/ionos-cloud/reprepro/issues/20#issuecomment-1110753298

I guess packaging for Ubuntu Jammy uses zstd.

Signed-off-by: David Galloway <dgallowa@redhat.com>