### PR TITLE
tox: add WebTest as a dependency of testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 deps=
   pytest
+  WebTest
 commands=py.test -v {posargs:chacra/tests}
 
 [testenv:flake8]


### PR DESCRIPTION
pecan uses it for running test. without adding this dependency, we'd
have following test failure:
```
>       from webtest import TestApp
E       ModuleNotFoundError: No module named 'webtest'
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>