### PR TITLE
Remove DDebComponents from distribution files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -443,7 +443,6 @@ by using the following configuration::
             "Architectures": "amd64 armhf i386 source",
             "Suite": "stable",
             "Components": "main",
-            "DDebComponents": "main",
         },
         "ceph": {
             "Description": "Ceph distributed file system",

--- a/config/dev.py
+++ b/config/dev.py
@@ -97,7 +97,6 @@ distributions = {
         "Architectures": "amd64 armhf i386 source",
         "Suite": "stable",
         "Components": "main",
-        "DDebComponents": "main",
     },
     "ceph": {
         "Description": "Ceph distributed file system",

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -332,7 +332,6 @@ distributions = {
         "Architectures": "amd64 arm64 armhf i386 source",
         "Suite": "stable",
         "Components": "main",
-        "DDebComponents": "main",
     },
     "ceph": {
         "Description": "Ceph distributed file system",


### PR DESCRIPTION
This has been spewing errors since at least 2019.  The weird part is I can't find any mention of DDebComponents anywhere in any reprepro source tree or Google comment.  O_o  There's some indication of it being an Ubuntu invention that hasn't yet made it to mainstream (?)