### PR TITLE
Update py.test to pytest

### DIFF
--- a/chacra/controllers/repos/__init__.py
+++ b/chacra/controllers/repos/__init__.py
@@ -4,7 +4,7 @@ import shutil
 
 from pecan import expose, abort, request, response
 from pecan.secure import secure
-from pecan.ext.notario import validate
+from pecan_notario import validate
 
 from chacra.models import Project
 from chacra.controllers import error

--- a/chacra/tests/async/test_callbacks.py
+++ b/chacra/tests/async/test_callbacks.py
@@ -16,7 +16,7 @@ repo_keys = [
 
 class TestHelpers(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
         self.repo = Repo(
             self.p,
@@ -25,7 +25,7 @@ class TestHelpers(object):
             distro_version='7',
             )
 
-    def teardown(self):
+    def teardown_method(self):
         # callback settings added in test_post_request are "sticky", this
         # ensures they are reset for other tests that rely on pristine conf
         # settings
@@ -57,10 +57,10 @@ class TestHelpers(object):
 
 class TestCallbackInvalidConf(object):
 
-    def setup(self):
+    def setup_method(self):
         conf.callback_url = 'http://localhost/callback'
 
-    def teardown(self):
+    def teardown_method(self):
         # callback settings added in setup are "sticky", this ensures they are
         # reset for other tests that rely on pristine conf settings
         conftest.reload_config()
@@ -79,12 +79,12 @@ class TestCallbackInvalidConf(object):
 
 class TestCallback(object):
 
-    def setup(self):
+    def setup_method(self):
         conf.callback_url = 'http://localhost/callback'
         conf.callback_user = 'admin'
         conf.callback_key = 'key'
 
-    def teardown(self):
+    def teardown_method(self):
         # callback settings added in setup are "sticky", this ensures they are
         # reset for other tests that rely on pristine conf settings
         conftest.reload_config()

--- a/chacra/tests/async/test_recurring.py
+++ b/chacra/tests/async/test_recurring.py
@@ -25,7 +25,7 @@ def no_update_timestamp():
 
 class TestPurgeRepos(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
         self.repo = Repo(
             self.p,
@@ -34,7 +34,7 @@ class TestPurgeRepos(object):
             distro_version='7',
             )
 
-        self.now = datetime.datetime.utcnow()
+        self.now = datetime.datetime.now(datetime.UTC)
         # slightly old
         self.one_minute = self.now - datetime.timedelta(minutes=1)
         # really old
@@ -43,7 +43,7 @@ class TestPurgeRepos(object):
         self.repo.modified = self.three_weeks_ago
         conf.purge_repos = True
 
-    def teardown(self):
+    def teardown_method(self):
         # callback settings added in test_post_request are "sticky", this
         # ensures they are reset for other tests that rely on pristine conf
         # settings

--- a/chacra/tests/controllers/repos/test_repos.py
+++ b/chacra/tests/controllers/repos/test_repos.py
@@ -1,6 +1,6 @@
 import os
 import pecan
-import py.test
+import pytest
 from chacra.models import Project, Repo, Binary
 from chacra.compat import b_
 from chacra import asynch
@@ -8,7 +8,7 @@ from chacra import asynch
 
 class TestRepoApiController(object):
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -28,7 +28,7 @@ class TestRepoApiController(object):
         result = session.app.get(url)
         assert result.json['archs'] == ['x86_64']
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/repo/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/repo/']
@@ -48,7 +48,7 @@ class TestRepoApiController(object):
         result = session.app.get(url)
         assert b_("deb") in result.body
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/centos/7/repo/',
              '/repos/foobar/firefly/head/centos/7/flavors/default/repo/']
@@ -70,7 +70,7 @@ class TestRepoApiController(object):
         assert b_("noarch") in result.body
         assert b_("SRPMS") in result.body
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
         'url',
         ['/repos/foobar-opensuse/firefly/head/opensuse/15.1/repo/',
          '/repos/foobar-opensuse/firefly/head/opensuse/15.1/flavors/default/repo/']
@@ -92,7 +92,7 @@ class TestRepoApiController(object):
         assert b_("noarch") not in result.body
         assert b_("SRPMS") not in result.body
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -115,7 +115,7 @@ class TestRepoApiController(object):
         assert result.json["ref"] == "firefly"
         assert result.json["sha1"] == "head"
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -138,7 +138,7 @@ class TestRepoApiController(object):
         assert result.json["sha1"] == "head"
 
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -158,7 +158,7 @@ class TestRepoApiController(object):
         assert result.status_int == 200
         assert result.json["is_queued"] is False
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -178,7 +178,7 @@ class TestRepoApiController(object):
         assert result.status_int == 200
         assert result.json["is_updating"] is False
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -198,7 +198,7 @@ class TestRepoApiController(object):
         assert result.status_int == 200
         assert result.json["type"] is None
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/precise/',
              '/repos/foobar/firefly/head/ubuntu/precise/flavors/default/']
@@ -217,7 +217,7 @@ class TestRepoApiController(object):
         result = session.app.get(url, expect_errors=True)
         assert result.status_int == 404
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/centos/trusty/',
              '/repos/foobar/firefly/head/centos/trusty/flavors/default/']
@@ -236,7 +236,7 @@ class TestRepoApiController(object):
         result = session.app.get(url, expect_errors=True)
         assert result.status_int == 404
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/hammer/head/ubuntu/trusty/',
              '/repos/foobar/hammer/head/ubuntu/trusty/flavors/default/']
@@ -255,7 +255,7 @@ class TestRepoApiController(object):
         result = session.app.get('/repos/foobar/hammer/head/ubuntu/trusty/', expect_errors=True)
         assert result.status_int == 404
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/sha1/ubuntu/trusty/',
              '/repos/foobar/firefly/sha1/ubuntu/trusty/flavors/default/']
@@ -274,7 +274,7 @@ class TestRepoApiController(object):
         result = session.app.get(url, expect_errors=True)
         assert result.status_int == 404
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -293,7 +293,7 @@ class TestRepoApiController(object):
         result = session.app.get(url)
         assert result.json['extra'] == {}
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/extra/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/extra/']
@@ -318,7 +318,7 @@ class TestRepoApiController(object):
         updated_repo = Repo.get(repo_id)
         assert updated_repo.extra == {"version": "0.94.8", 'distros': ['precise']}
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -345,7 +345,7 @@ class TestRepoApiController(object):
         assert updated_repo.distro_version == "precise"
         assert result.json['distro_version'] == "precise"
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -374,7 +374,7 @@ class TestRepoApiController(object):
         assert result.json['distro_version'] == "7"
         assert result.json['distro'] == "centos"
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -401,7 +401,7 @@ class TestRepoApiController(object):
         updated_repo = Repo.get(repo_id)
         assert updated_repo.distro == "ubuntu"
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -424,7 +424,7 @@ class TestRepoApiController(object):
         )
         assert result.status_int == 400
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/']
@@ -451,7 +451,7 @@ class TestRepoApiController(object):
 
 class TestRepoCRUDOperations(object):
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/update',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/update']
@@ -477,8 +477,8 @@ class TestRepoCRUDOperations(object):
         assert result.json['needs_update'] is True
         assert result.json['is_queued'] is False
 
-    @py.test.mark.dmick
-    @py.test.mark.parametrize(
+    @pytest.mark.dmick
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/'],
@@ -520,7 +520,7 @@ class TestRepoCRUDOperations(object):
         result = session.app.get(url)
         assert result.json['type'] == 'raw'
 
-    @py.test.mark.dmick
+    @pytest.mark.dmick
     def test_raw_post_update(self, session, recorder, monkeypatch):
         pecan.conf.repos_root = '/tmp/root'
         url = '/repos/foobar/main/head/windows/999/'
@@ -550,7 +550,7 @@ class TestRepoCRUDOperations(object):
         result = session.app.post(url + 'update/')
         assert fake_post_status.recorder_calls[0]['args'][0] == 'ready'
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/update',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/update']
@@ -569,7 +569,7 @@ class TestRepoCRUDOperations(object):
         result = session.app.head(url)
         assert result.status_int == 200
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/recreate',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/recreate']
@@ -591,7 +591,7 @@ class TestRepoCRUDOperations(object):
         assert result.json['needs_update'] is True
         assert result.json['is_queued'] is False
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/recreate',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/recreate']
@@ -616,7 +616,7 @@ class TestRepoCRUDOperations(object):
         assert result.json['needs_update'] is True
         assert result.json['is_queued'] is False
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/recreate',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/recreate']
@@ -638,7 +638,7 @@ class TestRepoCRUDOperations(object):
         assert os.path.exists(path) is True
         assert result.json['needs_update'] is True
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/recreate',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/recreate']
@@ -657,7 +657,7 @@ class TestRepoCRUDOperations(object):
         result = session.app.head(url)
         assert result.status_int == 200
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/recreate',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/recreate']
@@ -670,7 +670,7 @@ class TestRepoCRUDOperations(object):
         )
         assert result.status_int == 404
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/repos/foobar/firefly/head/ubuntu/trusty/recreate',
              '/repos/foobar/firefly/head/ubuntu/trusty/flavors/default/recreate']

--- a/chacra/tests/controllers/test_binaries.py
+++ b/chacra/tests/controllers/test_binaries.py
@@ -1,6 +1,6 @@
 import os
 import pecan
-import py.test
+import pytest
 
 from chacra.models import Binary, Project, Repo
 from chacra.tests import util
@@ -72,7 +72,7 @@ class TestBinaryUniqueness(object):
 
 class TestBinaryController(object):
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph/giant/head/ceph/el6/x86_64/',
              '/binaries/ceph/giant/head/ceph/el6/x86_64/flavors/default/']
@@ -86,7 +86,7 @@ class TestBinaryController(object):
         )
         assert result.status_int == 201
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph/giant/head/ceph/el6/x86_64/',
              '/binaries/ceph/giant/head/ceph/el6/x86_64/flavors/default/']
@@ -104,7 +104,7 @@ class TestBinaryController(object):
         )
         assert result.status_int == 405
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_get',
             [('/binaries/ceph/giant/head/ceph/el7/x86_64/',
               '/binaries/ceph/giant/head/ceph/el6/x86_64/'),
@@ -125,7 +125,7 @@ class TestBinaryController(object):
         )
         assert result.status_int == 404
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_get',
             [('/binaries/ceph/giant/head/ceph/el6/x86_64/',
             '/binaries/ceph/giant/head/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/'),
@@ -156,7 +156,7 @@ class TestBinaryController(object):
         result = session.app.get('/binaries/ceph/giant/head/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/', expect_errors=True)
         assert result.status_int == 404
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph/giant/head/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/',
             '/binaries/ceph/giant/head/ceph/el6/x86_64/flavors/default/ceph-9.0.0-0.el6.x86_64.rpm/']
@@ -175,7 +175,7 @@ class TestBinaryController(object):
         result = session.app.delete(url, expect_errors=True)
         assert result.status_int == 204
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph/giant/head/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/',
             '/binaries/ceph/giant/head/ceph/el6/x86_64/flavors/default/ceph-9.0.0-0.el6.x86_64.rpm/']
@@ -216,7 +216,7 @@ class TestBinaryController(object):
         p = Project.get(1)
         assert p.name == "ceph"
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_delete',
             [('/binaries/ceph/giant/head/ceph/el6/x86_64/',
             '/binaries/ceph/giant/head/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/'),
@@ -258,7 +258,7 @@ class TestBinaryController(object):
         repo = Repo.get(1)
         assert repo.needs_update
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph/giant/head/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm/',
             '/binaries/ceph/giant/head/ceph/el6/x86_64/flavors/default/ceph-9.0.0-0.el6.x86_64.rpm/']
@@ -291,7 +291,7 @@ class TestBinaryController(object):
         binary = Binary.get(1)
         assert binary.path.endswith('ceph/giant/head/ceph/el6/x86_64/ceph-9.0.0-0.el6.x86_64.rpm')
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_post_2',
             [('/binaries/ceph/giant/head/ceph/el6/x86_64/',
               '/binaries/ceph/giant/head/ceph/el6/x86_64/'),
@@ -314,7 +314,7 @@ class TestBinaryController(object):
 
         assert result.status_int == 400
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_post_2',
             [('/binaries/ceph/giant/head/ceph/el7/x86_64/',
               '/binaries/ceph/giant/head/ceph/el6/x86_64/'),
@@ -351,7 +351,7 @@ class TestBinaryController(object):
         contents = open(destination).read()
         assert contents == 'something changed'
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_get',
             [('/binaries/ceph/giant/head/ceph/el6/x86_64/',
               '/binaries/ceph/giant/head/ceph/el6/x86_64/'),
@@ -368,7 +368,7 @@ class TestBinaryController(object):
         result = response['ceph-9.0.0-0.el6.x86_64.rpm']['project']
         assert result == 'ceph'
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_get',
             [('/binaries/ceph/giant/head/ceph/el6/x86_64/',
               '/binaries/ceph/giant/head/ceph/el6/x86_64/'),
@@ -385,7 +385,7 @@ class TestBinaryController(object):
         result = response['ceph-9.0.0-0.el6.x86_64.rpm']['size']
         assert result == 13
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_get',
             [('/binaries/ceph/giant/head/ceph/el6/x86_64/',
               '/binaries/ceph/giant/head/ceph/el6/x86_64/'),
@@ -421,7 +421,7 @@ class TestBinaryController(object):
         result = response['ceph-9.0.0-0.el6.x86_64.rpm']['checksum']
         assert result.startswith('a5725e467')
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url_post, url_head',
             [('/binaries/ceph/giant/head/ceph/el6/x86_64/',
               '/binaries/ceph/giant/head/ceph/el6/x86_64/'),
@@ -440,7 +440,7 @@ class TestBinaryController(object):
 
 class TestRelatedProjects(object):
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph-deploy/main/head/centos/6/x86_64/',
              '/binaries/ceph-deploy/main/head/centos/6/x86_64/flavors/default/']
@@ -463,7 +463,7 @@ class TestRelatedProjects(object):
         repo = Repo.filter_by(project=project).first()
         assert repo.needs_update is True
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph-deploy/main/head/centos/6/x86_64/',
              '/binaries/ceph-deploy/main/head/centos/6/x86_64/flavors/default/']
@@ -487,7 +487,7 @@ class TestRelatedProjects(object):
         repo = Repo.filter_by(project=project).first()
         assert repo.needs_update is True
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph-deploy/main/head/centos/6/x86_64/',
              '/binaries/ceph-deploy/main/head/centos/6/x86_64/flavors/default/']
@@ -513,7 +513,7 @@ class TestRelatedProjects(object):
         assert Repo.filter_by(project=ceph_project).first().needs_update is True
         assert Repo.filter_by(project=rhcs_project).first().needs_update is True
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph-deploy/main/head/centos/6/x86_64/',
              '/binaries/ceph-deploy/main/head/centos/6/x86_64/flavors/default/']
@@ -538,7 +538,7 @@ class TestRelatedProjects(object):
 class TestAutomaticRepos(object):
     # these are not unittests :(
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph-deploy/main/head/centos/6/x86_64/',
              '/binaries/ceph-deploy/main/head/centos/6/x86_64/flavors/default/']
@@ -571,7 +571,7 @@ class TestAutomaticRepos(object):
         repo = Repo.filter_by(project=project).first()
         assert repo.needs_update is False
 
-    @py.test.mark.parametrize(
+    @pytest.mark.parametrize(
             'url',
             ['/binaries/ceph-deploy/main/head/centos/6/x86_64/',
              '/binaries/ceph-deploy/main/head/centos/6/x86_64/flavors/default/']

--- a/chacra/tests/models/test_binaries.py
+++ b/chacra/tests/models/test_binaries.py
@@ -3,7 +3,7 @@ from chacra.models import Binary, Project, Repo
 
 class TestBinaryModification(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
 
     def test_created_equals_modified_first_time_around(self, session):
@@ -156,7 +156,7 @@ class TestBinaryModification(object):
 
 class TestGenericBinaries(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
 
     def test_binary_is_generic(self, session):

--- a/chacra/tests/models/test_repos.py
+++ b/chacra/tests/models/test_repos.py
@@ -3,7 +3,7 @@ from chacra.models import Project, Repo, Binary
 
 class TestRepoModification(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
 
     def test_created_slaps_a_modified_attr(self, session):
@@ -42,7 +42,7 @@ class TestRepoModification(object):
 
 class TestInferType(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
 
     def test_rpm_is_inferred(self, session):
@@ -72,7 +72,7 @@ class TestInferType(object):
 
 class TestRepoArch(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
 
     def test_x86_64(self, session):
@@ -109,7 +109,7 @@ class TestRepoArch(object):
 
 class TestRepoMetricNames(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = Project('ceph')
 
     def test_full_metric_name(self, session):

--- a/chacra/tests/test_util.py
+++ b/chacra/tests/test_util.py
@@ -82,7 +82,7 @@ class TestRepoDirectory(object):
 
 class TestRepoPaths(object):
 
-    def setup(self):
+    def setup_method(self):
         self.repo = models.Repo(
             models.Project('ceph-deploy'),
             'main',
@@ -206,11 +206,12 @@ class TestCombined(object):
 
 class TestGetBinaries(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = models.Project('ceph')
 
     def test_no_project(self, session):
-        result = util.get_extra_binaries('f', 'ubuntu', 'precise')
+        with session.Session.no_autoflush:
+            result = util.get_extra_binaries('f', 'ubuntu', 'precise')
         assert result == []
 
     def test_no_matching_ref_without_specific_ref(self, session):
@@ -326,7 +327,7 @@ class TestGetBinaries(object):
 
 class TestRepreproCommand(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = models.Project('ceph')
 
     def test_deb_binary(self, session, tmpdir):
@@ -384,7 +385,7 @@ class TestRepreproCommand(object):
 
 class TestRepreproCommands(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = models.Project('ceph')
 
     def test_no_distro_versions_binary_non_generic(self, session, tmpdir):
@@ -474,7 +475,7 @@ class TestRepreproCommands(object):
 
 class TestGetDistributionsFileContext(object):
 
-    def setup(self):
+    def setup_method(self):
         self.distro_conf = {
             "defaults": {
                 "foo": "bar",
@@ -519,7 +520,7 @@ class TestGetDistributionsFileContext(object):
 
 class TestRepositoryIsDisabled(object):
 
-    def teardown(self):
+    def teardown_method(self):
         conftest.reload_config()
 
     def test_nothing_is_configured(self):
@@ -582,7 +583,7 @@ repos_conf = {
 
 class TestRelatedProjects(object):
 
-    def setup(self):
+    def setup_method(self):
         self.conf = dict()
 
     def test_nothing_is_related(self):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 deps=
   pytest
   WebTest
-commands=py.test -v {posargs:chacra/tests}
+commands=pytest -v {posargs:chacra/tests}
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
The invocation of the command py.test is no longer support. That and it's supported modules have moved to pytest to avoid confusion.

- Avoid using pecan.ext for import. This isn't working according to pecan/pecan#157
- Update tox to use pytest.
- Update imports to pytest.
- Update fixtures to use preferred setup_method and teardown_method method definitions.

Fixes: #322