### PR TITLE
Fix datetime.utcnow() warnings

### DIFF
--- a/chacra/asynch/recurring.py
+++ b/chacra/asynch/recurring.py
@@ -67,7 +67,7 @@ def purge_repos(_now=None):
         return
 
     # default value for repo life
-    now = _now or datetime.datetime.utcnow()
+    now = _now or datetime.datetime.now(datetime.UTC)
     default_lifespan = now - datetime.timedelta(days=14)
     default_keep_minimum = 0
 

--- a/chacra/controllers/util.py
+++ b/chacra/controllers/util.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import logging
 from pecan import conf
 
@@ -17,8 +17,8 @@ def repository_is_automatic(project_name, repo_config=None):
 
 
 def last_seen(timestamp):
-    now = datetime.utcnow()
-    difference = now - timestamp
+    now = datetime.now(UTC)
+    difference = now - timestamp.replace(tzinfo=UTC)
     formatted = ReadableSeconds(difference.seconds)
     return "%s ago" % formatted
 

--- a/chacra/models/__init__.py
+++ b/chacra/models/__init__.py
@@ -54,7 +54,7 @@ def update_timestamp(mapper, connection, target):
     """
     Automate the 'modified' attribute when a model changes
     """
-    target.modified = datetime.datetime.utcnow()
+    target.modified = datetime.datetime.now(datetime.UTC)
 
 
 # Utilities:

--- a/chacra/models/binaries.py
+++ b/chacra/models/binaries.py
@@ -50,7 +50,7 @@ class Binary(Base):
     def __init__(self, name, project, repo=None, **kw):
         self.name = name
         self.project = project
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
         self.created = now
         self.modified = now
         self.sha1 = kw.get('sha1', 'head')

--- a/chacra/models/repos.py
+++ b/chacra/models/repos.py
@@ -37,7 +37,7 @@ class Repo(Base):
         self.ref = ref
         self.distro = distro
         self.distro_version = distro_version
-        self.modified = datetime.datetime.utcnow()
+        self.modified = datetime.datetime.now(datetime.UTC)
         self.sha1 = kwargs.get('sha1', 'head')
         self.flavor = kwargs.get('flavor', 'default')
 


### PR DESCRIPTION
In Python 3, it's now preferred to pass the timezone to datetime.now(), as this method is deprecated.