### PR TITLE
Increase retention for nvmeof branches

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -127,6 +127,12 @@ purge_rotation = {
     },
     'ceph': {
         'ref': {
+            'squid-nvmeof': {
+                'keep_minimum': 2
+            },
+            'squid-nvmeof-8.0': {
+                'keep_minimum': 2
+            },
             'hammer': {
                 'days': 30,
                 'keep_minimum': 5


### PR DESCRIPTION
The NVMEoF team requested to keep builds around longer than the default 14 days; I've modified their request but hope this will serve.  Intended to be used in place of https://github.com/ceph/chacra/pull/325