### PR TITLE
Increase retention for nvmeof branches (part 2)

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -127,7 +127,10 @@ purge_rotation = {
     },
     'ceph': {
         'ref': {
-            'squid-nvmeof': {
+            'reef-nvmeof': {
+                'keep_minimum': 2
+            },
+	    'squid-nvmeof': {
                 'keep_minimum': 2
             },
             'squid-nvmeof-8.0': {


### PR DESCRIPTION
The NVMEoF team requested to keep builds around longer than the default 14 days; I've modified their request but hope this will serve.

part2 adds another release (reef)