### PR TITLE
nginx: raise client_max_body_size to 16 GiB

### DIFF
--- a/deploy/playbooks/roles/common/templates/nginx_site.conf
+++ b/deploy/playbooks/roles/common/templates/nginx_site.conf
@@ -26,8 +26,8 @@ server {
     access_log  /var/log/nginx/{{ app_name }}-access.log;
     error_log /var/log/nginx/{{ app_name }}-error.log;
 
-    # Some binaries are gigantic
-    client_max_body_size 4096m;
+    # Some binaries are gigantic: ceph-test-dbg debs passed 6 GiB in 2026
+    client_max_body_size 16384m;
 
     location / {
       proxy_set_header        Host $host;


### PR DESCRIPTION
The 4 GiB limit is now smaller than ceph's debug packages. [ceph-dev-pipeline build 8238](https://jenkins.ceph.com/job/ceph-dev-pipeline/8238/) failed uploading `ceph-test-dbg_21.3.0-*_amd64.deb` (4.44 GiB for noble, 6.13 GiB for jammy): nginx rejected the POSTs and closed the connection mid-stream, which chacractl saw as `SSLEOFError: EOF occurred in violation of protocol` after exhausting its retries.

From `1.chacra.ceph.com`'s nginx error log:

```
2026/08/14 05:17:50 [error] ... client intended to send too large body: 4772356374 bytes ... "POST /binaries/ceph/wip-build-speedups/.../ubuntu/noble/x86_64/flavors/default/ ..."
2026/08/14 05:43:29 [error] ... client intended to send too large body: 6578931828 bytes ... "POST /binaries/ceph/wip-build-speedups/.../ubuntu/jammy/x86_64/flavors/default/ ..."
```

Bumping to 16 GiB gives ~2.5x headroom over today's biggest package while keeping a finite cap as a guard against runaway uploads. The live chacra nodes have already been hotfixed with this value; this makes it survive the next ansible deploy.