### PR TITLE
deploy: enable pool_pre_ping and blacklist postgresql from unattended upgrades

### DIFF
--- a/deploy/playbooks/roles/common/defaults/main.yml
+++ b/deploy/playbooks/roles/common/defaults/main.yml
@@ -9,3 +9,7 @@ ssl_key_path: "files/ssl/dev/ssl.key"
 # this gives us a way to use self signed certs
 # on non-dev environments
 use_self_signed_ssl: False
+# packages unattended-upgrades must never touch (regexes anchored at the
+# start of the package name); postgresql server upgrades restart the cluster
+unattended_upgrades_package_blacklist:
+  - "postgresql-"

--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -47,6 +47,11 @@
   tags:
     - packages
 
+- include_tasks: unattended_upgrades.yml
+  tags:
+    - packages
+    - unattended-upgrades
+
 - name: Create a virtualenv with latest pip.
   pip: name=pip virtualenv={{ app_home }} extra_args='--upgrade' virtualenv_python=python3
 

--- a/deploy/playbooks/roles/common/tasks/unattended_upgrades.yml
+++ b/deploy/playbooks/roles/common/tasks/unattended_upgrades.yml
@@ -1,0 +1,29 @@
+---
+# Keep automatic security patching enabled, but keep service-critical
+# packages (postgresql server) out of it: the postgresql postinst restarts
+# the cluster, which drops chacra's pooled DB connections mid-run.
+# See https://tracker.ceph.com/issues/79947
+
+- name: install unattended-upgrades
+  become: true
+  apt:
+    name: unattended-upgrades
+    state: present
+
+- name: enable daily package list updates and unattended upgrades
+  become: true
+  template:
+    src: apt/20auto-upgrades.j2
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: blacklist service-critical packages from unattended upgrades
+  become: true
+  template:
+    src: apt/51chacra-unattended-upgrades.j2
+    dest: /etc/apt/apt.conf.d/51chacra-unattended-upgrades
+    owner: root
+    group: root
+    mode: "0644"

--- a/deploy/playbooks/roles/common/templates/apt/20auto-upgrades.j2
+++ b/deploy/playbooks/roles/common/templates/apt/20auto-upgrades.j2
@@ -1,0 +1,3 @@
+// {{ ansible_managed }}
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";

--- a/deploy/playbooks/roles/common/templates/apt/51chacra-unattended-upgrades.j2
+++ b/deploy/playbooks/roles/common/templates/apt/51chacra-unattended-upgrades.j2
@@ -1,0 +1,12 @@
+// {{ ansible_managed }}
+//
+// Packages excluded from unattended upgrades. Entries are python regexes
+// matched against the start of the package name.
+//
+// postgresql server upgrades restart the cluster; apply those manually
+// during a maintenance window instead.
+Unattended-Upgrade::Package-Blacklist {
+{% for pkg in unattended_upgrades_package_blacklist %}
+    "{{ pkg }}";
+{% endfor %}
+};

--- a/deploy/playbooks/roles/common/templates/prod_db.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_db.py.j2
@@ -5,5 +5,8 @@ sqlalchemy = {
     'echo':          False,
     'echo_pool':     False,
     'pool_recycle':  3600,
+    # test pooled connections before handing them out so a postgres
+    # restart doesn't surface as a burst of 500s from stale connections
+    'pool_pre_ping': True,
     'encoding':      'utf-8'
 }


### PR DESCRIPTION
## What

Two changes to the deploy role, both stemming from https://tracker.ceph.com/issues/79947:

- **`prod_db.py.j2`**: enable SQLAlchemy `pool_pre_ping` so pooled connections are tested (`SELECT 1`) before being handed out. A dead connection is transparently replaced instead of raising `OperationalError` to the client.
- **New `unattended_upgrades.yml` task file** in the common role: keeps automatic security upgrades enabled (now explicitly encoded via a managed `20auto-upgrades` instead of relying on distro defaults), and adds `51chacra-unattended-upgrades` blacklisting `postgresql-*` packages, driven by a `unattended_upgrades_package_blacklist` role default.

## Why

On 2026-08-22 at 07:00 UTC, unattended-upgrades applied the postgresql-14 14.23→14.24 security update on chacra3. The package postinst restarted the cluster, killing every gunicorn worker's pooled DB connection. For the next ~4 minutes each worker's first request failed with `psycopg2.OperationalError: SSL connection has been closed unexpectedly` → HTTP 500, which failed teuthology jobs mid-install (tracker 79947).

`pool_pre_ping` makes chacra survive *any* postgres restart regardless of cause; the blacklist keeps the one package whose upgrade restarts the DB server out of the automated path (to be applied manually in maintenance windows) while retaining security patching for everything else.

## Notes for reviewers

- chacra passes the whole `sqlalchemy` config dict straight to `create_engine()` (`chacra/models/__init__.py:_engine_from_config`), and the deployed SQLAlchemy 1.3 supports `pool_pre_ping` (added in 1.2), so no code change is needed.
- These exact rendered files have already been hand-deployed to the live nodes (chacra1/2 reloaded and verified; chacra3 and chacra.ceph.com pending a worker reload), so the next ansible run should report no changes there.
- Blacklist entries are python regexes anchored at the start of the package name; `postgresql-` covers the server, client, and common packages but deliberately not `libpq5`, whose upgrade doesn't restart the server.