### PR TITLE
Ubuntu Resolute support

### DIFF
--- a/chacra/constants.py
+++ b/chacra/constants.py
@@ -21,6 +21,7 @@ DISTRIBUTIONS = [
     'focal',
     'jammy',
     'noble',
+    'resolute',
 ]
 
 # These are reserved keys that will be ignored when processing repos. Otherwise

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -351,7 +351,7 @@ repos = {
         {% if combine_deb_repos|default(True) %}
         # note: 'universal' binaries will be included to all these distro
         # versions since they do not belong to any one in particular.
-        'combined': ['trixie', 'bookworm', 'bullseye', 'buster', 'stretch', 'wheezy', 'trusty', 'precise', 'jessie', 'xenial', 'bionic', 'focal', 'jammy', 'noble']
+        'combined': ['trixie', 'bookworm', 'bullseye', 'buster', 'stretch', 'wheezy', 'trusty', 'precise', 'jessie', 'xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute']
         {% endif %}
     },
     'cephmetrics': {


### PR DESCRIPTION
Add Ubuntu 26.04 (Resolute Raccoon) to the known distributions and the combined deb repo list, ahead of Ceph CI support for 26.04. Same shape as the noble change (#329).

Needs a chacra redeploy after merge.