### PR TITLE
openshift: carry an explicit namespace on every deploy manifest

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -158,3 +158,18 @@ Open the URL in your browser:
 ```
 https://<printed-host>/
 ```
+
+## Deploying to a different namespace
+
+Every document in `openshift/deploy/` carries an explicit
+`namespace: chacra` (a partially-namespaced set silently scatters the
+unnamespaced objects into whatever namespace your context points at).
+To deploy under another namespace, rewrite it first, e.g.:
+
+```
+sed -i 's/namespace: chacra$/namespace: my-chacra/' openshift/deploy/*.yaml*
+```
+
+and update the in-cluster image reference in `db-bootstrap-job.yaml` /
+`db-migration-job.yaml` (`image-registry.openshift-image-registry.svc:5000/chacra/chacra:latest`)
+to match.

--- a/openshift/deploy/chacra-nginx.yaml
+++ b/openshift/deploy/chacra-nginx.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: chacra-proxy
+  namespace: chacra
 spec:
   replicas: 1
   selector:
@@ -50,6 +51,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: chacra-proxy
+  namespace: chacra
 spec:
   selector:
     app: chacra-proxy
@@ -62,6 +64,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: chacra
+  namespace: chacra
 spec:
   to:
     kind: Service

--- a/openshift/deploy/chacra-nginx.yaml
+++ b/openshift/deploy/chacra-nginx.yaml
@@ -73,3 +73,4 @@ spec:
     targetPort: http
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/openshift/deploy/configmap.yaml
+++ b/openshift/deploy/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chacra-config
+  namespace: chacra
   labels: { app: chacra }
 data:
   config.py: |
@@ -181,6 +182,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chacra-wsgi
+  namespace: chacra
   labels: { app: chacra }
 data:
   # This module will be imported as "wsgi_wrapper"

--- a/openshift/deploy/rabbitmq.yaml
+++ b/openshift/deploy/rabbitmq.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rabbitmq
+  namespace: chacra
   labels: { app: chacra, tier: mq }
 spec:
   ports:
@@ -17,6 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq
+  namespace: chacra
   labels: { app: chacra, tier: mq }
 spec:
   replicas: 1

--- a/openshift/deploy/route.yaml
+++ b/openshift/deploy/route.yaml
@@ -13,4 +13,5 @@ spec:
     targetPort: http
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   # host: chacra.<your-apps-domain>   # optional

--- a/openshift/deploy/route.yaml
+++ b/openshift/deploy/route.yaml
@@ -2,6 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: chacra
+  namespace: chacra
   labels: { app: chacra }
 spec:
   to:

--- a/openshift/deploy/secret.yaml.example
+++ b/openshift/deploy/secret.yaml.example
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: chacra-secrets
+  namespace: chacra
   labels:
     app: chacra
 type: Opaque

--- a/openshift/deploy/service.yaml
+++ b/openshift/deploy/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: chacra
+  namespace: chacra
   labels: { app: chacra }
 spec:
   selector: { app: chacra, tier: api }


### PR DESCRIPTION
About half the documents under `openshift/deploy/` set `namespace: chacra` and half set none, so applying the directory without `-n` (or with the wrong current project) silently creates the unnamespaced half — the `chacra-config`/`chacra-wsgi` ConfigMaps, rabbitmq, the api Service, and the whole nginx proxy stack — in whatever namespace the kube context points at, while the Deployments land in `chacra` and then fail mounting ConfigMaps that "don't exist".

Hit this for real while standing up the `chacra-ceph-com` deployment on the Sepia cluster tonight.

This namespaces every document (`namespace.yaml` itself excepted) and documents how to retarget the set at a different namespace (sed the namespace, plus the in-cluster image path in the two db jobs).